### PR TITLE
Utility.GetAllFilesRecursively Improvements

### DIFF
--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -23,18 +23,14 @@ namespace Squirrel
         {
             Contract.Requires(rootPath != null);
 
-            return rootPath.GetDirectories()
-                .SelectMany(GetAllFilesRecursively)
-                .Concat(rootPath.GetFiles());
+            return rootPath.EnumerateFiles("*", SearchOption.AllDirectories);
         }
 
         public static IEnumerable<string> GetAllFilePathsRecursively(string rootPath)
         {
             Contract.Requires(rootPath != null);
 
-            return Directory.GetDirectories(rootPath)
-                .SelectMany(GetAllFilePathsRecursively)
-                .Concat(Directory.GetFiles(rootPath));
+            return Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories);
         }
 
         public static string CalculateFileSHA1(string filePath)


### PR DESCRIPTION
Apologies in advance for such minor changes and if I'm missing something obvious, but was there a reason why these don't use the built-in `SearchOption.AllDirectories` functionality, or just an oversight?

Both the previous implementation and these changes return the same results in my testing.

`EnumerateFiles` is used instead of `GetFiles`, to avoid allocating a (potentially large) array and allows enumerating through the results immediately without having to wait for the array to be created, filled, and returned.
