### PR TITLE
Clearer error message when no framework is provided in the nupkg file

### DIFF
--- a/src/Squirrel/ReleasePackage.cs
+++ b/src/Squirrel/ReleasePackage.cs
@@ -107,6 +107,11 @@ namespace Squirrel
 
                 throw new InvalidOperationException(String.Format(
                     "The input package file {0} targets multiple platforms - {1} - and cannot be transformed into a release package.", InputPackageFile, platforms));
+
+            } else if (!frameworks.Any()) {
+
+                throw new InvalidOperationException(String.Format(
+                    "The input package file {0} targets no platform and cannot be transformed into a release package.", InputPackageFile));
             }
 
             var targetFramework = frameworks.Single();


### PR DESCRIPTION
A very small addition to make error messages clearer when no framework dependencies are provided. Even better would be not to fail, but this still helps understand the message :) Otherwise, an `InvalidOperationException` is thrown with the message "Sequence contains no elements" (I had to look into the code to find what it was).

Note that I tried to follow conventions, though there were no tests for error cases, so I didn't add any. I still have to make xunit 2 work on Visual Studio Express...
