### PR TITLE
External process in same Window

### DIFF
--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -181,11 +181,9 @@ namespace Squirrel
             await Task.Run(() => pi.WaitForExit());
 
             string textResult = await pi.StandardOutput.ReadToEndAsync();
-            if(String.IsNullOrWhiteSpace(textResult))
-            {
+            if (String.IsNullOrWhiteSpace(textResult)) {
                 textResult = await pi.StandardError.ReadToEndAsync();
-                if(String.IsNullOrWhiteSpace(textResult))
-                {
+                if (String.IsNullOrWhiteSpace(textResult)) {
                     textResult = String.Empty;
                 }
             }

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -536,8 +536,7 @@ namespace Squirrel.Update
                     exe, signingOpts, exePath);
                 throw new Exception(msg);
             }
-            else
-            {
+            else {
                 Console.WriteLine(processResult.Item2);
             }
         }


### PR DESCRIPTION
When Squirrell calls another process, like Signtool.exe, it opens the process in a new Window and the process typically closes automatically so you cannot view details of the external operation.

This PR redirect the standard output and standard error of external processes to view details in the same console. This allows view what happens inside Signtool.exe in the Package Manager console.

![image](https://cloud.githubusercontent.com/assets/1263856/5195479/6674fbe2-74eb-11e4-8b53-a84e92a2ebe1.png)
