### PR TITLE
Always launch the app post install if already up to date. Fixes #69

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -325,7 +325,7 @@ namespace Squirrel
                     File.Copy(newSquirrel, Path.Combine(targetDir.Parent.FullName, "Update.exe"), true));
             }
 
-            async Task invokePostInstall(Version currentVersion, bool isInitialInstall, bool firstRunOnly)
+            async Task invokePostInstall(Version currentVersion, bool isInitialInstall, bool runOnly)
             {
                 var targetDir = getDirectoryForRelease(currentVersion);
                 var args = isInitialInstall ?
@@ -337,7 +337,7 @@ namespace Squirrel
                 this.Log().Info("Squirrel Enabled Apps: [{0}]", String.Join(",", squirrelApps));
 
                 // For each app, run the install command in-order and wait
-                if (!firstRunOnly) await squirrelApps.ForEachAsync(exe => Utility.InvokeProcessAsync(exe, args), 1 /* at a time */);
+                if (!runOnly) await squirrelApps.ForEachAsync(exe => Utility.InvokeProcessAsync(exe, args), 1 /* at a time */);
 
                 // If this is the first run, we run the apps with first-run and 
                 // *don't* wait for them, since they're probably the main EXE
@@ -354,7 +354,7 @@ namespace Squirrel
                     squirrelApps.ForEach(x => CreateShortcutsForExecutable(Path.GetFileName(x), ShortcutLocation.Desktop | ShortcutLocation.StartMenu, isInitialInstall == false));
                 }
 
-                if (!isInitialInstall) return;
+                if (!isInitialInstall && !runOnly) return;
 
                 var firstRunParam = isInitialInstall ? "--squirrel-firstrun" : "";
                 squirrelApps.ForEach(exe => Process.Start(exe, firstRunParam));


### PR DESCRIPTION
This maintains existing behaviour unless both isInitialInstall and firstRunOnly (now renamed to runOnly) are true, which only happens if no release was selected for install.

Previously, given those parameters, invokePostInstall would create shortcuts for non-squirrel-aware applications, then return. Now in addition to creating said shortcuts, it will run the application, which appears to be the intended behaviour.

This makes rerunning the installer start the installed application again after ebb6bb2c5a4c9d05f0abaaff99efe904f7232f4d
