### PR TITLE
Added a shortcut location for the application root directory

### DIFF
--- a/src/Squirrel/IUpdateManager.cs
+++ b/src/Squirrel/IUpdateManager.cs
@@ -15,7 +15,11 @@ namespace Squirrel
     public enum ShortcutLocation {
         StartMenu = 1 << 0,
         Desktop = 1 << 1,
-        Startup = 1 << 2
+        Startup = 1 << 2,
+        /// <summary>
+        /// A shortcut in the application folder, useful for portable applications.
+        /// </summary>
+        AppRoot = 1 << 3
     }
 
     public interface IUpdateManager : IDisposable, IEnableLogger

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -114,7 +114,7 @@ namespace Squirrel
                 var exePath = Path.Combine(Utility.AppDirForRelease(rootAppDirectory, thisRelease), exeName);
                 var fileVerInfo = FileVersionInfo.GetVersionInfo(exePath);
 
-                foreach (var f in new[] { ShortcutLocation.StartMenu, ShortcutLocation.Desktop, ShortcutLocation.Startup, }) {
+                foreach (var f in (ShortcutLocation[]) Enum.GetValues(typeof(ShortcutLocation))) {
                     if (!locations.HasFlag(f)) continue;
 
                     var file = linkTargetForVersionInfo(f, zf, fileVerInfo);
@@ -572,6 +572,9 @@ namespace Squirrel
                     break;
                 case ShortcutLocation.Startup:
                     dir = Environment.GetFolderPath (Environment.SpecialFolder.Startup);
+                    break;
+                case ShortcutLocation.AppRoot:
+                    dir = rootAppDirectory;
                     break;
                 }
 

--- a/test/ApplyReleasesTests.cs
+++ b/test/ApplyReleasesTests.cs
@@ -459,11 +459,11 @@ namespace Squirrel.Tests
                 }
 
                 var fixture = new UpdateManager.ApplyReleasesImpl("theApp", Path.Combine(path, "theApp"));
-                fixture.CreateShortcutsForExecutable("SquirrelAwareApp.exe", ShortcutLocation.Desktop | ShortcutLocation.StartMenu | ShortcutLocation.Startup, false);
+                fixture.CreateShortcutsForExecutable("SquirrelAwareApp.exe", ShortcutLocation.Desktop | ShortcutLocation.StartMenu | ShortcutLocation.Startup | ShortcutLocation.AppRoot, false);
 
                 // NB: COM is Weird.
                 Thread.Sleep(1000);
-                fixture.RemoveShortcutsForExecutable("SquirrelAwareApp.exe", ShortcutLocation.Desktop | ShortcutLocation.StartMenu | ShortcutLocation.Startup);
+                fixture.RemoveShortcutsForExecutable("SquirrelAwareApp.exe", ShortcutLocation.Desktop | ShortcutLocation.StartMenu | ShortcutLocation.Startup | ShortcutLocation.AppRoot);
 
                 // NB: Squirrel-Aware first-run might still be running, slow
                 // our roll before blowing away the temp path


### PR DESCRIPTION
This is useful for creating a shortcut for a portable application

I've also replaced the hardcoded ShortcutLocation array with Enum.GetValues, so it's a bit more maintainable
