### PR TITLE
Don't let --releasify overwrite existing packages

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -321,8 +321,7 @@ namespace Squirrel.Update
                 previousReleases = ReleaseEntry.ParseReleaseFile(File.ReadAllText(releaseFilePath, Encoding.UTF8));
             }
 
-            try
-            {
+            try {
                 foreach (var file in toProcess) {
                     this.Log().Info("Creating release package: " + file.FullName);
 
@@ -356,8 +355,7 @@ namespace Squirrel.Update
                 }
             }
             
-            finally
-            {
+            finally {
                 foreach (var file in toProcess) { File.Delete(file.FullName); }
             }
 


### PR DESCRIPTION
--releasify now throws an exception if there's already a package with the same version

This behavior can be overridden with the -force or -f flag

Fixes #42
