### PR TITLE
Don't attempt to download the icon, if the .nuspec file doesn't specify one

### DIFF
--- a/src/Squirrel/UpdateManager.InstallHelpers.cs
+++ b/src/Squirrel/UpdateManager.InstallHelpers.cs
@@ -49,7 +49,7 @@ namespace Squirrel
                 var key = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default)
                     .CreateSubKey(uninstallRegSubKey + "\\" + applicationName, RegistryKeyPermissionCheck.ReadWriteSubTree);
 
-                if (!File.Exists(targetIco)) {
+                if (zp.IconUrl != null && !File.Exists(targetIco)) {
                     try {
                         var wc = Utility.CreateWebClient();
 


### PR DESCRIPTION
Previously the exception handler below catched the `ArgumentNullException` in `DownloadFileTaskAsync`, but we can improve this by checking for the icon beforehand
