### PR TITLE
Set working directory when process is started after installation.

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -357,7 +357,9 @@ namespace Squirrel
                 if (!isInitialInstall || silentInstall) return;
 
                 var firstRunParam = isInitialInstall ? "--squirrel-firstrun" : "";
-                squirrelApps.ForEach(exe => Process.Start(exe, firstRunParam));
+                squirrelApps
+                    .Select(exe => new ProcessStartInfo(exe, firstRunParam) { WorkingDirectory = Path.GetDirectoryName(exe) })
+                    .ForEach(info => Process.Start(info));
             }
 
             void fixPinnedExecutables(Version newCurrentVersion) 


### PR DESCRIPTION
Working directory is set to the directory the process is located in.
This should prevent different behaviour between the post-install-start and a subsequent start.
