### PR TITLE
Fix Squirrel memory usage

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -175,7 +175,7 @@ namespace Squirrel
 
             async Task<string> installPackageToAppDir(UpdateInfo updateInfo, ReleaseEntry release)
             {
-                var pkg = new ZipPackage(Path.Combine(updateInfo.PackageDirectory, release.Filename));
+                var pkg = new OptimizedZipPackage(Path.Combine(updateInfo.PackageDirectory, release.Filename));
                 var target = getDirectoryForRelease(release.Version);
 
                 // NB: This might happen if we got killed partially through applying the release


### PR DESCRIPTION
Instead of using `ZipPackage` while extracting the archive, use `OptimizedZipPackage` which apparently extracts to a temp directory so it doesn't use 1GB of memory

## TODO:

- [x] Make sure this actually works