### PR TITLE
Fix Silent Install

### DIFF
--- a/src/Setup/UpdateRunner.cpp
+++ b/src/Setup/UpdateRunner.cpp
@@ -96,11 +96,11 @@ int CUpdateRunner::ExtractUpdaterAndRun(wchar_t* lpCommandLine)
 	si.dwFlags = STARTF_USESHOWWINDOW;
 
 	if (!lpCommandLine || wcsnlen_s(lpCommandLine, MAX_PATH) < 1) {
-		lpCommandLine = L"--install .";
+		lpCommandLine = L"";
 	}
 
 	wchar_t cmd[MAX_PATH];
-	swprintf_s(cmd, L"\"%s\" %s", updateExePath, lpCommandLine);
+	swprintf_s(cmd, L"\"%s\" --install . %s", updateExePath, lpCommandLine);
 
 	if (!CreateProcess(NULL, cmd, NULL, NULL, false, 0, NULL, targetDir, &si, &pi)) {
 		goto failedExtract;

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -116,7 +116,10 @@ namespace Squirrel.Update
 
                 switch (updateAction) {
                 case UpdateAction.Install:
-                    AnimatedGifWindow.ShowWindow(TimeSpan.FromSeconds(4), animatedGifWindowToken.Token);
+                    if (!silentInstall) { 
+                        AnimatedGifWindow.ShowWindow(TimeSpan.FromSeconds(4), animatedGifWindowToken.Token);
+                    }
+
                     Install(silentInstall, Path.GetFullPath(target)).Wait();
                     break;
                 case UpdateAction.Uninstall:


### PR DESCRIPTION
This PR fixes the Silent switch which allows you to install an app without UI:

```
setup.exe -s
or
setup.exe --silent
```

Fixes #161