### PR TITLE
SingleGlobalInstance constructor should set the existing IDisposable variable "handle" to overcome locking errors instead of creating a new one and never using it.

### DIFF
--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -555,7 +555,7 @@ namespace Squirrel
                 throw new Exception("Couldn't acquire lock, is another instance running");
             }
 
-            var handle = Disposable.Create(() => {
+            handle = Disposable.Create(() => {
                 fh.Dispose();
                 File.Delete(path);
             });


### PR DESCRIPTION
I actually don't get why a new handle variable is created in SingleGlobalInstance constructor. When disposing, it's always null, so Interlocked.Exchange(ref handle, null) returns null. As a result if (disp != null) disp.Dispose(); never executes, so the lock file is never deleted. This causes locking errors in subsequent calls to UpdateManager's methods, even after disposing it after each call (wrapping each call in using statements of course).

By setting the existing handle variable instead of creating a new one and never using it, I could overcome my problems as described in #138.

@paulcbetts If my commit causes problems I am not able to see, since I am not really familiar with the project's code, please enlighten me. After this change though, I am able to use Squirrel now :)