### PR TITLE
Fix appname install directory

### DIFF
--- a/src/Squirrel/ReleaseEntry.cs
+++ b/src/Squirrel/ReleaseEntry.cs
@@ -23,6 +23,7 @@ namespace Squirrel
         Version Version { get; }
         string PackageName { get; }
 
+        string GetPackageId(string packageDirectory);
         string GetReleaseNotes(string packageDirectory);
     }
 
@@ -53,9 +54,22 @@ namespace Squirrel
         [IgnoreDataMember]
         public Version Version { get { return Filename.ToVersion(); } }
 
+        [Obsolete("Property is deprecated because it may not correctly retrieve package names (a.k.a. Id's) if you have periods in it.  If you wish to retrieve the package Id, please use the GetPackageId method.")]
         [IgnoreDataMember]
         public string PackageName {
             get { return Filename.Substring(0, Filename.IndexOfAny(new[] { '-', '.' })); }
+        }
+
+        public string GetPackageId(string packageDirectory)
+        {
+            var zp = new ZipPackage(Path.Combine(packageDirectory, Filename));
+
+            if (String.IsNullOrWhiteSpace(zp.Id))
+            {
+                throw new Exception(String.Format("Invalid 'Id' value in nuspec file at '{0}'", Path.Combine(packageDirectory, Filename)));
+            }
+
+            return zp.Id;
         }
 
         public string GetReleaseNotes(string packageDirectory)

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -162,7 +162,7 @@ namespace Squirrel.Update
             }
 
             var ourAppName = ReleaseEntry.ParseReleaseFile(File.ReadAllText(releasesPath, Encoding.UTF8))
-                .First().PackageName;
+                .First().GetPackageId(sourceDirectory);
 
             using (var mgr = new UpdateManager(sourceDirectory, ourAppName, FrameworkVersion.Net45)) {
                 Directory.CreateDirectory(mgr.RootAppDirectory);

--- a/test/ReleaseEntryTests.cs
+++ b/test/ReleaseEntryTests.cs
@@ -69,6 +69,18 @@ namespace Squirrel.Tests.Core
             Assert.Equal(expectedMinor, fixture.Version.Minor);
         }
 
+        [Theory]
+        [InlineData("Squirrel.Core.1.0.0.0.nupkg", "NSync.Core")]
+        [InlineData("Squirrel.Core.NoDependencies.1.0.0.0", "NSync.Core")]
+        [InlineData("ProjectWithContent.1.0.0.0-beta.nupkg", "ProjectWithContent")]
+        public void ParsePackageIdFromReleaseEntryTest(string packageFileName, string packageId)
+        {
+            var path = IntegrationTestHelper.GetPath("fixtures", packageFileName);
+            var fixture = ReleaseEntry.GenerateFromFile(path);
+
+            Assert.Equal(packageId, fixture.GetPackageId(IntegrationTestHelper.GetPath("fixtures")));
+        }
+
         [Fact]
         public void CanParseGeneratedReleaseEntryAsString()
         {


### PR DESCRIPTION
Paul, I think I fixed the problem where the directory name of the installed app was not getting set properly if a package Id had a period in it.

Please review :worried: 