### PR TITLE
Specify Shortcut Locations on Update.exe

### DIFF
--- a/src/Squirrel/IUpdateManager.cs
+++ b/src/Squirrel/IUpdateManager.cs
@@ -13,6 +13,7 @@ namespace Squirrel
 {
     [Flags]
     public enum ShortcutLocation {
+        None = 0,
         StartMenu = 1 << 0,
         Desktop = 1 << 1,
         Startup = 1 << 2,

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -115,6 +115,7 @@ namespace Squirrel
                 var fileVerInfo = FileVersionInfo.GetVersionInfo(exePath);
 
                 foreach (var f in (ShortcutLocation[]) Enum.GetValues(typeof(ShortcutLocation))) {
+                    if (f == ShortcutLocation.None) continue;
                     if (!locations.HasFlag(f)) continue;
 
                     var file = linkTargetForVersionInfo(f, zf, fileVerInfo);
@@ -161,6 +162,7 @@ namespace Squirrel
                     Path.Combine(Utility.AppDirForRelease(rootAppDirectory, thisRelease), exeName));
 
                 foreach (var f in (ShortcutLocation[]) Enum.GetValues(typeof(ShortcutLocation))) {
+                    if (f == ShortcutLocation.None) continue;
                     if (!locations.HasFlag(f)) continue;
 
                     var file = linkTargetForVersionInfo(f, zf, fileVerInfo);


### PR DESCRIPTION
New argument that gives users control of the shortcuts that Update.exe manages.
Usage: 
`"l=|shortcut-locations=", "Comma-separated string of shortcut locations, e.g. 'Desktop,StartMenu'"`

### TODO:
- [x] Test this thoroughly
- [ ] Code review