### PR TITLE
Sync from standard http

### DIFF
--- a/src/SyncGitHubReleases/Program.cs
+++ b/src/SyncGitHubReleases/Program.cs
@@ -79,68 +79,60 @@ namespace SyncGitHubReleases
 
         private async Task SyncFromGitHub(string repoUrl, string token, DirectoryInfo releaseDirectoryInfo)
         {
-            var repoUri = new Uri(repoUrl);
-            var userAgent = new ProductHeaderValue("SyncGitHubReleases", Assembly.GetExecutingAssembly().GetName().Version.ToString());
-            var client = new GitHubClient(userAgent, repoUri)
-            {
-                Credentials = new Credentials(token)
-            };
+                var repoUri = new Uri(repoUrl);
+                var userAgent = new ProductHeaderValue("SyncGitHubReleases", Assembly.GetExecutingAssembly().GetName().Version.ToString());
+                var client = new GitHubClient(userAgent, repoUri) {
+                    Credentials = new Credentials(token)
+                };
 
-            var nwo = nwoFromRepoUrl(repoUrl);
-            var releases = (await client.Release.GetAll(nwo.Item1, nwo.Item2))
-                .OrderByDescending(x => x.PublishedAt)
-                .Take(2);
+                var nwo = nwoFromRepoUrl(repoUrl);
+                var releases = (await client.Release.GetAll(nwo.Item1, nwo.Item2))
+                    .OrderByDescending(x => x.PublishedAt)
+                    .Take(2);
 
-            await releases.ForEachAsync(async release =>
-            {
-                // NB: Why do I have to double-fetch the release assets? It's already in GetAll
-                var assets = await client.Release.GetAssets(nwo.Item1, nwo.Item2, release.Id);
+                await releases.ForEachAsync(async release => {
+                    // NB: Why do I have to double-fetch the release assets? It's already in GetAll
+                    var assets = await client.Release.GetAssets(nwo.Item1, nwo.Item2, release.Id);
 
-                await assets
-                    .Where(x => x.Name.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
-                    .Where(x =>
-                    {
-                        var fi = new FileInfo(Path.Combine(releaseDirectoryInfo.FullName, x.Name));
-                        return !(fi.Exists && fi.Length == x.Size);
-                    })
-                    .ForEachAsync(async x =>
-                    {
-                        var target = new FileInfo(Path.Combine(releaseDirectoryInfo.FullName, x.Name));
-                        if (target.Exists) target.Delete();
-                        var retryCount = 3;
+                    await assets
+                        .Where(x => x.Name.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
+                        .Where(x => {
+                            var fi = new FileInfo(Path.Combine(releaseDirectoryInfo.FullName, x.Name));
+                            return !(fi.Exists && fi.Length == x.Size);
+                        })
+                        .ForEachAsync(async x => {
+                            var target = new FileInfo(Path.Combine(releaseDirectoryInfo.FullName, x.Name));
+                            if (target.Exists) target.Delete();
+                            var retryCount = 3;
 
-                    retry:
+                        retry:
 
-                        try
-                        {
-                            var hc = new HttpClient();
-                            var rq = new HttpRequestMessage(HttpMethod.Get, x.Url);
-                            rq.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/octet-stream"));
-                            rq.Headers.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue(userAgent.Name, userAgent.Version));
-                            rq.Headers.Add("Authorization", "Bearer " + token);
+                            try {
+                                var hc = new HttpClient();
+                                var rq = new HttpRequestMessage(HttpMethod.Get, x.Url);
+                                rq.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/octet-stream"));
+                                rq.Headers.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue(userAgent.Name, userAgent.Version));
+                                rq.Headers.Add("Authorization", "Bearer " + token);
 
-                            var resp = await hc.SendAsync(rq);
-                            resp.EnsureSuccessStatusCode();
+                                var resp = await hc.SendAsync(rq);
+                                resp.EnsureSuccessStatusCode();
 
-                            using (var from = await resp.Content.ReadAsStreamAsync())
-                            using (var to = File.OpenWrite(target.FullName))
-                            {
-                                await from.CopyToAsync(to);
+                                using (var from = await resp.Content.ReadAsStreamAsync())
+                                using (var to = File.OpenWrite(target.FullName)) {
+                                    await from.CopyToAsync(to);
+                                }
+                            } catch (Exception ex) {
+                                if (--retryCount > 0) goto retry;
+                                throw;
                             }
-                        }
-                        catch (Exception ex)
-                        {
-                            if (--retryCount > 0) goto retry;
-                            throw;
-                        }
-                    });
-            });
+                        });
+                });
 
-            var entries = releaseDirectoryInfo.GetFiles("*.nupkg")
-                .AsParallel()
-                .Select(x => ReleaseEntry.GenerateFromFile(x.FullName));
+                var entries = releaseDirectoryInfo.GetFiles("*.nupkg")
+                    .AsParallel()
+                    .Select(x => ReleaseEntry.GenerateFromFile(x.FullName));
 
-            ReleaseEntry.WriteReleaseFile(entries, Path.Combine(releaseDirectoryInfo.FullName, "RELEASES"));
+                ReleaseEntry.WriteReleaseFile(entries, Path.Combine(releaseDirectoryInfo.FullName, "RELEASES"));
         }
         
         public void ShowHelp()

--- a/src/SyncGitHubReleases/Program.cs
+++ b/src/SyncGitHubReleases/Program.cs
@@ -59,20 +59,18 @@ namespace SyncGitHubReleases
                     return -1;
                 }
 
-                var releasesDirectoryInfo = new DirectoryInfo(releaseDir ?? Path.Combine(".", "Releases"));
-                
-                if (!releasesDirectoryInfo.Exists) 
-                    releasesDirectoryInfo.Create();
+                var releaseDirectoryInfo = new DirectoryInfo(releaseDir ?? Path.Combine(".", "Releases"));
+                if (!releaseDirectoryInfo.Exists) releaseDirectoryInfo.Create();
 
                 if (token == null)
                 {
                     Console.WriteLine("No GitHub token specified so assuming URL points to existing RELEASES file");
-                    await new StandardHttpSyncer(new Uri(repoUrl)).Sync(releasesDirectoryInfo);
+                    await new StandardHttpSyncer(new Uri(repoUrl)).Sync(releaseDirectoryInfo);
                 }
                 else
                 {
                     Console.WriteLine("GitHub token was specified, so will create Releases directory from repository");
-                    await SyncFromGitHub(repoUrl, token, releasesDirectoryInfo);
+                    await SyncFromGitHub(repoUrl, token, releaseDirectoryInfo);
                 }
             }
 

--- a/src/SyncGitHubReleases/StandardHttpSyncer.cs
+++ b/src/SyncGitHubReleases/StandardHttpSyncer.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Squirrel;
+
+namespace SyncGitHubReleases
+{
+    internal class StandardHttpSyncer
+    {
+        private readonly Uri m_Uri;
+
+        public StandardHttpSyncer(Uri uri)
+        {
+            m_Uri = uri;
+        }
+
+        public async Task Sync(DirectoryInfo releasesDir)
+        {
+            
+            var releasesIndex = await DownloadReleasesIndex(m_Uri);
+
+            File.WriteAllText(Path.Combine(releasesDir.FullName, "RELEASES"), releasesIndex);
+
+            var releasesToDownload = ReleaseEntry.ParseReleaseFile(releasesIndex)
+                .Where(x => !x.IsDelta)
+                .OrderByDescending(x => x.Version)
+                .Take(2)
+                .Select(x => new
+                             {
+                                 LocalPath = Path.Combine(releasesDir.FullName, x.Filename),
+                                 RemoteUrl = new Uri(m_Uri, x.Filename)
+                             }
+                );
+
+            foreach (var releaseToDownload in releasesToDownload)
+                await DownloadRelease(releaseToDownload.LocalPath, releaseToDownload.RemoteUrl);
+        }
+
+        private async Task<string> DownloadReleasesIndex(Uri repoUrl)
+        {
+            var uri = new Uri(repoUrl, "RELEASES");
+
+            Console.WriteLine("Trying to download RELEASES index from {0}", uri);
+
+            using (HttpClient client = new HttpClient())
+            {
+                return await client.GetStringAsync(uri);
+            }
+        }
+
+        private async Task DownloadRelease(string localPath, Uri remoteUrl)
+        {
+            if (File.Exists(localPath))
+            {
+                Console.WriteLine("Skipping this release as existing file found at: {0}", localPath);
+                return;
+            }
+
+            using (HttpClient client = new HttpClient())
+            {
+                using (var localStream = File.Create(localPath))
+                {
+                    using (var remoteStream = await client.GetStreamAsync(remoteUrl))
+                    {
+                        await remoteStream.CopyToAsync(localStream);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/SyncGitHubReleases/StandardHttpSyncer.cs
+++ b/src/SyncGitHubReleases/StandardHttpSyncer.cs
@@ -58,6 +58,8 @@ namespace SyncGitHubReleases
                 return;
             }
 
+            Console.WriteLine("Downloading release from {0}", remoteUrl);
+
             using (HttpClient client = new HttpClient())
             {
                 using (var localStream = File.Create(localPath))

--- a/src/SyncGitHubReleases/StandardHttpSyncer.cs
+++ b/src/SyncGitHubReleases/StandardHttpSyncer.cs
@@ -18,7 +18,6 @@ namespace SyncGitHubReleases
 
         public async Task Sync(DirectoryInfo releasesDir)
         {
-            
             var releasesIndex = await DownloadReleasesIndex(m_Uri);
 
             File.WriteAllText(Path.Combine(releasesDir.FullName, "RELEASES"), releasesIndex);

--- a/src/SyncGitHubReleases/SyncGitHubReleases.csproj
+++ b/src/SyncGitHubReleases/SyncGitHubReleases.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Mono.Options\Options.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StandardHttpSyncer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />


### PR DESCRIPTION
Resolves #194

1. Reuses the `-u` arg and the presence of the GitHub token is what is used to choose between syncing with GitHub or treating the url as a standard http location

2. Didn't implement retry although can later if needed.

3. Tried to make as few changes to the existing code as possible.

4. Skips an existing `nupkg` if it exists on disk. Didn't bother with SHA1 checking