### PR TITLE
Ensure that Squirrel.exe itself never gets a shortcut

### DIFF
--- a/src/Squirrel/SquirrelAwareExecutableDetector.cs
+++ b/src/Squirrel/SquirrelAwareExecutableDetector.cs
@@ -29,7 +29,8 @@ namespace Squirrel
             if (!File.Exists(executable)) return null;
             var fullname = Path.GetFullPath(executable);
 
-            return GetAssemblySquirrelAwareVersion(fullname) ?? GetVersionBlockSquirrelAwareValue(fullname);
+            return Utility.Retry<int?>(() => 
+                GetAssemblySquirrelAwareVersion(fullname) ?? GetVersionBlockSquirrelAwareValue(fullname));
         }
 
         static int? GetAssemblySquirrelAwareVersion(string executable)

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -95,6 +95,7 @@ namespace Squirrel
                         } else {
                             var allApps = currentRelease.EnumerateFiles()
                                 .Where(x => x.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                                .Where(x => !x.Name.StartsWith("squirrel.", StringComparison.OrdinalIgnoreCase))
                                 .ToList();
 
                             allApps.ForEach(x => RemoveShortcutsForExecutable(x.Name, ShortcutLocation.StartMenu | ShortcutLocation.Desktop));
@@ -349,6 +350,7 @@ namespace Squirrel
 
                     squirrelApps = targetDir.EnumerateFiles()
                         .Where(x => x.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                        .Where(x => !x.Name.StartsWith("squirrel.", StringComparison.OrdinalIgnoreCase))
                         .Select(x => x.FullName)
                         .ToList();
 


### PR DESCRIPTION
This attempts to ensure atom/atom#5296 doesn't happen in different ways. #189 should also improve this situation.