### PR TITLE
Fix infinite shortcut issues

### DIFF
--- a/src/Squirrel/ShellFile.cs
+++ b/src/Squirrel/ShellFile.cs
@@ -8,17 +8,11 @@ using System.Windows.Forms;
 
 namespace Squirrel
 {
-    #region ShellLink Object
-
     /// <summary>
     /// Summary description for ShellLink.
     /// </summary>
     public class ShellLink : IDisposable
     {
-        #region ComInterop for IShellLink
-
-        #region IPersist Interface
-
         [ComImport()]
         [Guid("0000010C-0000-0000-C000-000000000046")]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
@@ -28,10 +22,6 @@ namespace Squirrel
             //[helpstring("Returns the class identifier for the component object")]
             void GetClassID(out Guid pClassID);
         }
-
-        #endregion
-
-        #region IPersistFile Interface
 
         [ComImport()]
         [Guid("0000010B-0000-0000-C000-000000000046")]
@@ -64,9 +54,46 @@ namespace Squirrel
                 [MarshalAs(UnmanagedType.LPWStr)] out string ppszFileName);
         }
 
-        #endregion
+        [StructLayout(LayoutKind.Sequential)]
+        public struct PropVariant
+        {
+            public short variantType;
+            public short Reserved1, Reserved2, Reserved3;
+            public IntPtr pointerValue;
+        }
 
-        #region IShellLink Interface
+        [StructLayout(LayoutKind.Sequential)]
+        public struct PROPERTYKEY
+        {
+            public Guid fmtid;
+            public UIntPtr pid;
+
+            public static PROPERTYKEY PKEY_AppUserModel_ID {
+                get {
+                    return new PROPERTYKEY() {
+                        fmtid = Guid.ParseExact("{9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}", "B"),
+                        pid = new UIntPtr(5),
+                    };
+                }
+            }
+        }
+
+        [ComImport]
+        [Guid("886D8EEB-8CF2-4446-8D02-CDBA1DBDCF99")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        interface IPropertyStore
+        {
+            [PreserveSig]
+            int GetCount([Out] out uint cProps);
+            [PreserveSig]
+            int GetAt([In] uint iProp, out PROPERTYKEY pkey);
+            [PreserveSig]
+            int GetValue([In] ref PROPERTYKEY key, out PropVariant pv);
+            [PreserveSig]
+            int SetValue([In] ref PROPERTYKEY key, [In] ref object pv);
+            [PreserveSig]
+            int Commit();
+        }
 
         [ComImport()]
         [Guid("000214EE-0000-0000-C000-000000000046")]
@@ -230,20 +257,12 @@ namespace Squirrel
                 [MarshalAs(UnmanagedType.LPWStr)] string pszFile);
         }
 
-        #endregion
-
-        #region ShellLinkCoClass
-
         [Guid("00021401-0000-0000-C000-000000000046")]
         [ClassInterface(ClassInterfaceType.None)]
         [ComImport()]
         class CShellLink
         {
         }
-
-        #endregion
-
-        #region Private IShellLink enumerations
 
         enum EShellLinkGP : uint
         {
@@ -269,10 +288,6 @@ namespace Squirrel
             SW_SHOWDEFAULT = 10,
             SW_MAX = 10
         }
-
-        #endregion
-
-        #region IShellLink Private structs
 
         [StructLayout(LayoutKind.Sequential, Pack = 4, Size = 0,
             CharSet = CharSet.Unicode)]
@@ -321,10 +336,6 @@ namespace Squirrel
             public uint dwHighDateTime;
         }
 
-        #endregion
-
-        #region UnManaged Methods
-
         class UnManagedMethods
         {
             [DllImport("Shell32", CharSet = CharSet.Auto)]
@@ -338,12 +349,6 @@ namespace Squirrel
             [DllImport("user32")]
             internal static extern int DestroyIcon(IntPtr hIcon);
         }
-
-        #endregion
-
-        #endregion
-
-        #region Enumerations
 
         /// <summary>
         /// Flags determining how the links with missing
@@ -421,18 +426,10 @@ namespace Squirrel
             edmMaximized = EShowWindowFlags.SW_MAXIMIZE
         }
 
-        #endregion
-
-        #region Member Variables
-
         // Use Unicode (W) under NT, otherwise use ANSI      
         IShellLinkW linkW;
         IShellLinkA linkA;
         string shortcutFile = "";
-
-        #endregion
-
-        #region Constructor
 
         /// <summary>
         /// Creates an instance of the Shell Link object.
@@ -459,10 +456,6 @@ namespace Squirrel
             Open(linkFile);
         }
 
-        #endregion
-
-        #region Destructor and Dispose
-
         /// <summary>
         /// Call dispose just in case it hasn't happened yet
         /// </summary>
@@ -487,10 +480,6 @@ namespace Squirrel
                 linkA = null;
             }
         }
-
-        #endregion
-
-        #region Implementation
 
         public string ShortCutFile
         {
@@ -863,6 +852,12 @@ namespace Squirrel
             }
         }
 
+        public void SetAppUserModelId(string appId)
+        {
+            var propStore = (IPropertyStore)linkW;
+            propStore.SetValue(PROPERTYKEY.PKEY_AppUserModel_ID, appId);
+        }
+
         /// <summary>
         /// Saves the shortcut to ShortCutFile.
         /// </summary>
@@ -967,11 +962,7 @@ namespace Squirrel
                 this.shortcutFile = linkFile;
             }
         }
-
-        #endregion
     }
-
-    #endregion
 
     /// <summary>
     /// Enables extraction of icons for any file type from
@@ -979,8 +970,6 @@ namespace Squirrel
     /// </summary>
     public class FileIcon
     {
-        #region UnmanagedCode
-
         const int MAX_PATH = 260;
 
         [StructLayout(LayoutKind.Sequential)]
@@ -1029,19 +1018,11 @@ namespace Squirrel
         [DllImport("kernel32")]
         static extern int GetLastError();
 
-        #endregion
-
-        #region Member Variables
-
         string fileName;
         string displayName;
         string typeName;
         SHGetFileInfoConstants flags;
         Icon fileIcon;
-
-        #endregion
-
-        #region Enumerations
 
         [Flags]
         public enum SHGetFileInfoConstants : int
@@ -1065,10 +1046,6 @@ namespace Squirrel
             SHGFI_ADDOVERLAYS = 0x000000020, // apply the appropriate overlays
             SHGFI_OVERLAYINDEX = 0x000000040 // Get the index of the overlay
         }
-
-        #endregion
-
-        #region Implementation
 
         /// <summary>
         /// Gets/sets the flags used to extract the icon
@@ -1163,9 +1140,9 @@ namespace Squirrel
         {
             flags = SHGetFileInfoConstants.SHGFI_ICON |
                 SHGetFileInfoConstants.SHGFI_DISPLAYNAME |
-                    SHGetFileInfoConstants.SHGFI_TYPENAME |
-                        SHGetFileInfoConstants.SHGFI_ATTRIBUTES |
-                            SHGetFileInfoConstants.SHGFI_EXETYPE;
+                SHGetFileInfoConstants.SHGFI_TYPENAME |
+                SHGetFileInfoConstants.SHGFI_ATTRIBUTES |
+                SHGetFileInfoConstants.SHGFI_EXETYPE;
         }
 
         /// <summary>
@@ -1197,7 +1174,5 @@ namespace Squirrel
             this.flags = flags;
             GetInfo();
         }
-
-        #endregion
     }
 }

--- a/src/Squirrel/ShellFile.cs
+++ b/src/Squirrel/ShellFile.cs
@@ -60,6 +60,16 @@ namespace Squirrel
             public short variantType;
             public short Reserved1, Reserved2, Reserved3;
             public IntPtr pointerValue;
+
+            public static PropVariant FromString(string str)
+            {
+                var pv = new PropVariant() {
+                    variantType = 31,  // VT_LPWSTR
+                    pointerValue = Marshal.StringToCoTaskMemUni(str),
+                };
+
+                return pv;
+            }
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -90,7 +100,7 @@ namespace Squirrel
             [PreserveSig]
             int GetValue([In] ref PROPERTYKEY key, out PropVariant pv);
             [PreserveSig]
-            int SetValue([In] ref PROPERTYKEY key, [In] ref object pv);
+            int SetValue([In] ref PROPERTYKEY key, [In] ref PropVariant pv);
             [PreserveSig]
             int Commit();
         }
@@ -855,7 +865,7 @@ namespace Squirrel
         public void SetAppUserModelId(string appId)
         {
             var propStore = (IPropertyStore)linkW;
-            propStore.SetValue(PROPERTYKEY.PKEY_AppUserModel_ID, appId);
+            propStore.SetValue(PROPERTYKEY.PKEY_AppUserModel_ID, PropVariant.FromString(appId));
         }
 
         /// <summary>

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -125,6 +125,7 @@ namespace Squirrel
             {
                 var releases = Utility.LoadLocalReleases(Utility.LocalReleaseFileForAppDir(rootAppDirectory));
                 var thisRelease = Utility.FindCurrentVersion(releases);
+                var updateExe = getUpdateExe();
 
                 var zf = new ZipPackage(Path.Combine(
                     Utility.PackageDirectoryForAppDir(rootAppDirectory),
@@ -154,11 +155,12 @@ namespace Squirrel
                         if (fileExists) File.Delete(file);
 
                         var sl = new ShellLink {
-                            Target = exePath,
+                            Target = updateExe,
                             IconPath = exePath,
                             IconIndex = 0,
                             WorkingDirectory = Path.GetDirectoryName(exePath),
                             Description = zf.Description,
+                            Arguments = "--processStart " + exeName,
                         };
 
                         sl.SetAppUserModelId(String.Format("com.squirrel.{0}.{1}", zf.Id, exeName.Replace(".exe", "")));

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -159,6 +159,8 @@ namespace Squirrel
                             Description = zf.Description,
                         };
 
+                        sl.SetAppUserModelId(String.Format("com.squirrel.{0}.{1}", zf.Id, exeName.Replace(".exe", "")));
+
                         this.Log().Info("About to save shortcut: {0}", file);
                         if (ModeDetector.InUnitTestRunner() == false) sl.Save(file);
                     }, "Can't write shortcut: " + file);

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -115,6 +115,8 @@ namespace Squirrel
                     }
                 }
 
+                fixPinnedExecutables(new Version(255, 255, 255, 255));
+
                 await this.ErrorIfThrows(() => Utility.DeleteDirectoryWithFallbackToNextReboot(rootAppDirectory),
                     "Failed to delete app directory: " + rootAppDirectory);
             }

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -151,10 +151,25 @@ namespace Squirrel
 
                     this.Log().Info("Creating shortcut for {0} => {1}", exeName, file);
 
+                    ShellLink sl;
                     this.ErrorIfThrows(() => {
-                        if (fileExists) File.Delete(file);
+                        if (fileExists) {
+                            try {
+                                sl = new ShellLink();
 
-                        var sl = new ShellLink {
+                                sl.Open(file);
+                                if (sl.Target == updateExe && sl.Description == zf.Description && sl.IconPath == exePath) {
+                                    return;
+                                }
+
+                                File.Delete(file);
+                            } catch (Exception ex) {
+                                this.Log().WarnException("Tried to compare shortcut and failed", ex);
+                                File.Delete(file);
+                            }
+                        }
+
+                        sl = new ShellLink {
                             Target = updateExe,
                             IconPath = exePath,
                             IconIndex = 0,

--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -224,7 +224,16 @@ namespace Squirrel
 
         static string getUpdateExe()
         {
-            var assembly = Assembly.GetExecutingAssembly();
+            var assembly = Assembly.GetEntryAssembly();
+
+            // Are we update.exe?
+            if (assembly != null &&
+                Path.GetFileName(assembly.Location).Equals("update.exe", StringComparison.OrdinalIgnoreCase) &&
+                assembly.Location.IndexOf("app-", StringComparison.OrdinalIgnoreCase) == -1) {
+                return Path.GetFullPath(assembly.Location);
+            }
+
+            assembly = Assembly.GetExecutingAssembly();
 
             var updateDotExe = Path.Combine(Path.GetDirectoryName(assembly.Location), "..\\Update.exe");
             var target = new FileInfo(updateDotExe);

--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -181,7 +181,7 @@ namespace Squirrel
 
             exiting = true;
 
-            Process.Start(getUpdateExe(), String.Format("--processStart {0} {1}", exeToStart, argsArg));
+            Process.Start(getUpdateExe(), String.Format("--processStartAndWait {0} {1}", exeToStart, argsArg));
 
             // NB: We have to give update.exe some time to grab our PID, but
             // we can't use WaitForInputIdle because we probably don't have

--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -197,7 +197,10 @@ namespace Squirrel
                     if (pi.WaitForExit(2000)) return;
                 }
 
-                ct.ThrowIfCancellationRequested();
+                if (ct.IsCancellationRequested) {
+                    pi.Kill();
+                    ct.ThrowIfCancellationRequested();
+                }
             });
 
             string textResult = await pi.StandardOutput.ReadToEndAsync();

--- a/test/UtilityTests.cs
+++ b/test/UtilityTests.cs
@@ -14,6 +14,21 @@ namespace Squirrel.Tests.Core
     public class UtilityTests : IEnableLogger
     {
         [Fact]
+        public void SetAppIdOnShortcutTest()
+        {
+            var sl = new ShellLink() {
+                Target = @"C:\Windows\Notepad.exe",
+                Description = "It's Notepad",
+            };
+
+            sl.SetAppUserModelId("org.paulbetts.test");
+            var path = Path.GetFullPath(@".\test.lnk");
+            sl.Save(path);
+
+            Console.WriteLine("Saved to " + path);
+        }
+
+        [Fact]
         public void RemoveByteOrderMarkerIfPresent()
         {
             var utf32Be = new byte[] { 0x00, 0x00, 0xFE, 0xFF };


### PR DESCRIPTION
This PR fixes a bunch of issues around shortcuts and um other stuff

* Kill Squirrel Event processes that get cancelled
* We set the AppID which should convince pins to not get dupes showing up when people pin an old version then update to a new version
* Instead of creating shortcuts to the EXE itself, we instead create a shortcut to Update.exe which then always runs the latest version of the EXE
* Instead of always recreating shortcuts, we'll leave them alone if they're already pointing to what we want

## TODO:

- [x] Make sure this actually works