### PR TITLE
Added deletion guard for temporary file

### DIFF
--- a/src/Squirrel/FileDownloader.cs
+++ b/src/Squirrel/FileDownloader.cs
@@ -22,10 +22,10 @@ namespace Squirrel
 
         retry:
             try {
-                this.Log().Info("Downloading file: " + failedUrl ?? url);
+                this.Log().Info("Downloading file: " + (failedUrl ?? url));
 
                 await this.WarnIfThrows(() => wc.DownloadFileTaskAsync(failedUrl ?? url, targetFile),
-                    "Failed downloading URL: " + failedUrl ?? url);
+                    "Failed downloading URL: " + (failedUrl ?? url));
             } catch (Exception) {
                 // NB: Some super brain-dead services are case-sensitive yet 
                 // corrupt case on upload. I can't even.
@@ -45,10 +45,10 @@ namespace Squirrel
 
         retry:
             try {
-                this.Log().Info("Downloading url: " + failedUrl ?? url);
+                this.Log().Info("Downloading url: " + (failedUrl ?? url));
 
                 return await this.WarnIfThrows(() => wc.DownloadDataTaskAsync(failedUrl ?? url),
-                    "Failed to download url: " + failedUrl ?? url);
+                    "Failed to download url: " + (failedUrl ?? url));
             } catch (Exception) {
                 // NB: Some super brain-dead services are case-sensitive yet 
                 // corrupt case on upload. I can't even.

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -495,7 +495,7 @@ namespace Squirrel.Update
             opts.WriteOptionDescriptions(Console.Out);
         }
 
-        static void waitForParentToExit()
+        void waitForParentToExit()
         {
             // Grab a handle the parent process
             var parentPid = NativeMethods.GetParentProcessId();
@@ -504,9 +504,12 @@ namespace Squirrel.Update
             // Wait for our parent to exit
             try {
                 handle = NativeMethods.OpenProcess(ProcessAccess.Synchronize, false, parentPid);
-                if (handle == IntPtr.Zero) throw new Win32Exception();
-
-                NativeMethods.WaitForSingleObject(handle, 0xFFFFFFFF /*INFINITE*/);
+                if (handle != IntPtr.Zero) {
+                    this.Log().Info("About to wait for parent PID {0}", parentPid);
+                    NativeMethods.WaitForSingleObject(handle, 0xFFFFFFFF /*INFINITE*/);
+                } else {
+                    this.Log().Info("Parent PID {0} no longer valid - ignoring", parentPid);
+                }
             } finally {
                 if (handle != IntPtr.Zero) NativeMethods.CloseHandle(handle);
             }


### PR DESCRIPTION
After reading issue #231, I had a quick look for references to `Path.GetTempFileName()` to look for leaks.  The first one I found was in `DeltaPackageBuilder.applyDiffToFile`.   This PR is a proposed fix for this - it removes an internal try/catch block (with a File.Delete-and-rethrow), and replaces it with an overall try/finally, which closes at least two routes by which temporary files might be leaked.

It looks like a huge patch because of the changing indent, it's only a couple of lines, really.

I've not done any testing on this, and I've not reviewed any of the other uses of `Path.GetTempFileName` for the same sort of issues.    I'm happy to go through them all and and do the same sort of thing if you'd like.

Another approach I've used in other projects is to make a simple wrapper for temporary files, which is both IDisposable AND implements a finalizer to delete the file if you forget to Dispose it - I'd be happy to do something like that instead if you preferred.


