### PR TITLE
Reboot if necessary after .NET framework installation

### DIFF
--- a/src/Setup/FxHelper.cpp
+++ b/src/Setup/FxHelper.cpp
@@ -253,7 +253,12 @@ out:
 // Deal with the aftermath of the framework installer telling us that we need to reboot
 bool CFxHelper::HandleRebootRequirement(bool isQuiet)
 {
-	if (!isQuiet) {
+	if (isQuiet) {
+		// Don't silently reboot - just error-out
+		fprintf_s(stderr, "A reboot is required following .NET installation - reboot then run installer again.\n");
+		return false;
+	}
+	else {
 		CTaskDialog dlg;
 		TASKDIALOG_BUTTON buttons[] = {
 			{ 1, L"Restart Now", },

--- a/src/Setup/FxHelper.cpp
+++ b/src/Setup/FxHelper.cpp
@@ -229,6 +229,13 @@ HRESULT CFxHelper::InstallDotNetFramework(bool isQuiet)
 		goto out;
 	}
 
+	if (exitCode == 1641 || exitCode == 3010) {
+		// The framework installer wants a reboot before we can continue
+		// See https://msdn.microsoft.com/en-us/library/ee942965%28v=vs.110%29.aspx
+		HandleRebootRequirement(isQuiet);
+		// Exit as a failure, so that setup doesn't carry on now
+	}
+
 	hr = exitCode != 0 ? E_FAIL : S_OK;
 
 out:
@@ -242,3 +249,84 @@ out:
 
 	return hr;
 }
+
+// Deal with the aftermath of the framework installer telling us that we need to reboot
+bool CFxHelper::HandleRebootRequirement(bool isQuiet)
+{
+	if (!isQuiet) {
+		CTaskDialog dlg;
+		TASKDIALOG_BUTTON buttons[] = {
+			{ 1, L"Restart Now", },
+			{ 2, L"Restart Later", },
+		};
+
+		dlg.SetButtons(buttons, 2);
+		dlg.SetMainInstructionText(L"Restart System");
+		dlg.SetContentText(L"To finish installing the .NET Framework 4.5, the system now needs to restart.  The installation will finish after you restart and log-in again.");
+		dlg.SetMainIcon(TD_INFORMATION_ICON);
+
+		dlg.SetExpandedInformationText(L"If you click 'Restart Later', you'll need to re-run this setup program yourself, after restarting your system.");
+
+		int nButton;
+		if (FAILED(dlg.DoModal(::GetActiveWindow(), &nButton)) || nButton != 1) {
+			return false;
+		}
+	}
+
+	// We need to set up a runonce entry to restart this installer once the reboot has happened
+	if (!WriteRunOnceEntry()) {
+		return false;
+	}
+
+	// And now, reboot
+	return RebootSystem();
+}
+
+//
+// Write a runonce entry to the registry to tell it to continue with 
+// setup after a reboot
+//
+bool CFxHelper::WriteRunOnceEntry()
+{
+	ATL::CRegKey key;
+
+	if (key.Open(HKEY_CURRENT_USER, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce", KEY_WRITE) != ERROR_SUCCESS) {
+		return false;
+	}
+
+	TCHAR exePath[MAX_PATH];
+	GetModuleFileName(NULL, exePath, MAX_PATH);
+
+	if (key.SetStringValue(L"SquirrelInstall", exePath) != ERROR_SUCCESS) {
+		return false;
+	}
+
+	return true;
+}
+
+bool CFxHelper::RebootSystem()
+{
+	// First we need to enable the SE_SHUTDOWN_NAME privilege
+	LUID luid;
+	if (!LookupPrivilegeValue(L"", SE_SHUTDOWN_NAME, &luid)) {
+		return false;
+	}
+
+	HANDLE hToken = NULL;
+	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &hToken)) {
+		return false;
+	}
+
+	TOKEN_PRIVILEGES tp;
+	tp.PrivilegeCount = 1;
+	tp.Privileges[0].Luid = luid;
+	tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+	if (!AdjustTokenPrivileges(hToken, FALSE, &tp, sizeof(tp), NULL, 0)) {
+		CloseHandle(hToken);
+		return false;
+	}
+
+	// Now we have that privilege, we can ask Windows to restart
+	return ExitWindowsEx(EWX_REBOOT, 0) != 0;
+}
+

--- a/src/Setup/FxHelper.h
+++ b/src/Setup/FxHelper.h
@@ -5,5 +5,9 @@ class CFxHelper
 public:
 	static bool IsDotNet45OrHigherInstalled();
 	static HRESULT InstallDotNetFramework(bool isQuiet);
+private:
+	static bool HandleRebootRequirement(bool isQuiet);
+	static bool WriteRunOnceEntry();
+	static bool RebootSystem();
 };
 


### PR DESCRIPTION
See #252 - this PR checks for the .NET framework installer return codes which indicate that a restart is required (without which the rest of the Squirrel install will fail).  

It then sets up a runonce entry to continue the installation after reboot, and does a reboot.   The installer will re-run after a reboot, and proceed as normal, because the framework is now available.

