### PR TITLE
Fix #251

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -339,9 +339,9 @@ namespace Squirrel.Update
             var processed = new List<string>();
 
             var releaseFilePath = Path.Combine(di.FullName, "RELEASES");
-            var previousReleases = Enumerable.Empty<ReleaseEntry>();
+            var previousReleases = new List<ReleaseEntry>();
             if (File.Exists(releaseFilePath)) {
-                previousReleases = ReleaseEntry.ParseReleaseFile(File.ReadAllText(releaseFilePath, Encoding.UTF8));
+                previousReleases.AddRange(ReleaseEntry.ParseReleaseFile(File.ReadAllText(releaseFilePath, Encoding.UTF8)));
             }
 
             foreach (var file in toProcess) {
@@ -371,7 +371,9 @@ namespace Squirrel.Update
 
             foreach (var file in toProcess) { File.Delete(file.FullName); }
 
-            var releaseEntries = previousReleases.Concat(processed.Select(packageFilename => ReleaseEntry.GenerateFromFile(packageFilename, baseUrl)));
+            var newReleaseEntries = processed.Select(packageFilename => ReleaseEntry.GenerateFromFile(packageFilename, baseUrl)).ToList();
+            var distinctPreviousReleases = previousReleases.Where(x => !newReleaseEntries.Select(e => e.Version).Contains(x.Version));
+            var releaseEntries = distinctPreviousReleases.Concat(newReleaseEntries).ToList();
             ReleaseEntry.WriteReleaseFile(releaseEntries, releaseFilePath);
 
             var targetSetupExe = Path.Combine(di.FullName, "Setup.exe");


### PR DESCRIPTION
I also changed the type of `previousReleases` to be a list to avoid multiple enumerations.

I'm not sure if I also should create some tests. Currently there is no test project for the "Update" project. All tests seem to test functionality on the "customer"-side.