### PR TITLE
Update.exe - Add timestamp to log messages, and log unhandled exceptions

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -52,11 +52,23 @@ namespace Squirrel.Update
             //AnimatedGifWindow.ShowWindow(TimeSpan.FromMilliseconds(0), animatedGifWindowToken.Token);
             //Thread.Sleep(10 * 60 * 1000);
 
+            using (var logger = new SetupLogLogger(isUninstalling) {Level = LogLevel.Info}) {
+                Locator.CurrentMutable.Register(() => logger, typeof (Splat.ILogger));
+                try {
+                    return executeCommandLine(args);
+                } catch (Exception ex) {
+                    logger.Write("Unhandled exception: " + ex, LogLevel.Fatal);
+                    throw;
+                }
+                // Ideally we would deregister the logger from the Locator before it was disposed - this is a hazard as it is at the moment
+            }
+        }
+
+        int executeCommandLine(string[] args)
+        {
             var animatedGifWindowToken = new CancellationTokenSource();
 
-            using (Disposable.Create(() => animatedGifWindowToken.Cancel()))
-            using (var logger = new SetupLogLogger(isUninstalling) { Level = Splat.LogLevel.Info }) {
-                Splat.Locator.CurrentMutable.Register(() => logger, typeof(Splat.ILogger));
+            using (Disposable.Create(() => animatedGifWindowToken.Cancel())) {
 
                 this.Log().Info("Starting Squirrel Updater: " + String.Join(" ", args));
 
@@ -699,13 +711,13 @@ namespace Squirrel.Update
             }
         }
 
-        public void Write(string message, Splat.LogLevel logLevel)
+        public void Write(string message, LogLevel logLevel)
         {
             if (logLevel < Level) {
                 return;
             }
 
-            lock (gate) inner.WriteLine(message);
+            lock (gate) inner.WriteLine("{0}> {1}", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"), message);
         }
 
         public void Dispose()


### PR DESCRIPTION
We are really struggling to diagnose failed upgrades at the moment, and something which would help us (and the OP of #239) is time-stamping in the log, along with a record of exceptions that have caused update.exe to fail completely.

We had to rearrange things slightly so that the logger is above the exception handler, but other than that it's a very minor mod.  Having two try/catch blocks is unnecessary but I was trying to make the patch as small as possible.  

Date/time stamps are in local time, in a format roughly like ISO8601, to avoid any international date order confusion.



