### PR TITLE
Use alternative means to generate temp file names

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ILRepack" version="1.25.0" />
-  <package id="xunit.runners" version="2.0.0-beta5-build2785" />
+  <package id="xunit.runners" version="2.0.0-rc3-build2880" />
 </packages>

--- a/src/Squirrel/DeltaPackage.cs
+++ b/src/Squirrel/DeltaPackage.cs
@@ -186,7 +186,9 @@ namespace Squirrel
             var inputFile = Path.Combine(deltaPath, relativeFilePath);
             var finalTarget = Path.Combine(workingDirectory, Regex.Replace(relativeFilePath, @".diff$", ""));
 
-            var tempTargetFile = Path.GetTempFileName();
+            var tempTargetFile = default(string);
+            Utility.WithTempFile(out tempTargetFile);
+
             try {
                 // NB: Zero-length diffs indicate the file hasn't actually changed
                 if (new FileInfo(inputFile).Length == 0) {

--- a/src/Squirrel/ReleaseEntry.cs
+++ b/src/Squirrel/ReleaseEntry.cs
@@ -191,7 +191,9 @@ namespace Squirrel
             // Write the new RELEASES file to a temp file then move it into
             // place
             var entries = entriesQueue.ToList();
-            var tempFile = Path.GetTempFileName();
+            var tempFile = default(string);
+            Utility.WithTempFile(out tempFile);
+
             try {
                 using (var of = File.OpenWrite(tempFile)) {
                     if (entries.Count > 0) WriteReleaseFile(entries, of);

--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -229,7 +229,8 @@ namespace Squirrel
             // Are we update.exe?
             if (assembly != null &&
                 Path.GetFileName(assembly.Location).Equals("update.exe", StringComparison.OrdinalIgnoreCase) &&
-                assembly.Location.IndexOf("app-", StringComparison.OrdinalIgnoreCase) == -1) {
+                assembly.Location.IndexOf("app-", StringComparison.OrdinalIgnoreCase) == -1 &&
+                assembly.Location.IndexOf("SquirrelTemp", StringComparison.OrdinalIgnoreCase) == -1) {
                 return Path.GetFullPath(assembly.Location);
             }
 

--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -231,12 +231,13 @@ namespace Squirrel
 
         static Lazy<string> directoryChars = new Lazy<string>(() => {
             return "abcdefghijklmnopqrstuvwxyz" +
-                Enumerable.Range(0x4E00, 0x9FCC - 0x4E00)  // CJK UNIFIED IDEOGRAPHS
+                Enumerable.Range(0x03B0, 0x03FF - 0x03B0)   // Greek and Coptic
+                    .Concat(Enumerable.Range(0x0400, 0x04FF - 0x0400)) // Cyrillic
                     .Aggregate(new StringBuilder(), (acc, x) => { acc.Append(Char.ConvertFromUtf32(x)); return acc; })
                     .ToString();
         });
 
-        static string tempNameForIndex(int index, string prefix)
+        internal static string tempNameForIndex(int index, string prefix)
         {
             if (index < directoryChars.Value.Length) {
                 return prefix + directoryChars.Value[index];

--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -342,12 +342,6 @@ namespace Squirrel
             }
         }
 
-        public static Tuple<string, Stream> CreateTempFile()
-        {
-            var path = Path.GetTempFileName();
-            return Tuple.Create(path, (Stream) File.OpenWrite(path));
-        }
-
         public static string AppDirForRelease(string rootAppDirectory, ReleaseEntry entry)
         {
             return Path.Combine(rootAppDirectory, "app-" + entry.Version.ToString());

--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -229,7 +229,22 @@ namespace Squirrel
                 }));
         }
 
-        static string directoryChars;
+        static Lazy<string> directoryChars = new Lazy<string>(() => {
+            return "abcdefghijklmnopqrstuvwxyz" +
+                Enumerable.Range(0x4E00, 0x9FCC - 0x4E00)  // CJK UNIFIED IDEOGRAPHS
+                    .Aggregate(new StringBuilder(), (acc, x) => { acc.Append(Char.ConvertFromUtf32(x)); return acc; })
+                    .ToString();
+        });
+
+        static string tempNameForIndex(int index, string prefix)
+        {
+            if (index < directoryChars.Value.Length) {
+                return prefix + directoryChars.Value[index];
+            }
+
+            return prefix + directoryChars.Value[index % directoryChars.Value.Length] + tempNameForIndex(index / directoryChars.Value.Length, "");
+        }
+
         public static IDisposable WithTempDirectory(out string path)
         {
             var di = new DirectoryInfo(Environment.GetEnvironmentVariable("SQUIRREL_TEMP") ?? Environment.GetEnvironmentVariable("TEMP") ?? "");
@@ -239,14 +254,10 @@ namespace Squirrel
 
             var tempDir = default(DirectoryInfo);
 
-            directoryChars = directoryChars ?? (
-                "abcdefghijklmnopqrstuvwxyz" +
-                Enumerable.Range(0x4E00, 0x9FCC - 0x4E00)  // CJK UNIFIED IDEOGRAPHS
-                    .Aggregate(new StringBuilder(), (acc, x) => { acc.Append(Char.ConvertFromUtf32(x)); return acc; })
-                    .ToString());
+            var names = Enumerable.Range(0, 1<<20).Select(x => tempNameForIndex(x, "temp"));
 
-            foreach (var c in directoryChars) {
-                var target = Path.Combine(di.FullName, c.ToString());
+            foreach (var name in names) {
+                var target = Path.Combine(di.FullName, name);
 
                 if (!File.Exists(target) && !Directory.Exists(target)) {
                     Directory.CreateDirectory(target);
@@ -258,6 +269,28 @@ namespace Squirrel
             path = tempDir.FullName;
 
             return Disposable.Create(() => Task.Run(async () => await DeleteDirectory(tempDir.FullName)).Wait());
+        }
+
+        public static IDisposable WithTempFile(out string path)
+        {
+            var di = new DirectoryInfo(Environment.GetEnvironmentVariable("SQUIRREL_TEMP") ?? Environment.GetEnvironmentVariable("TEMP") ?? "");
+            if (!di.Exists) {
+                throw new Exception("%TEMP% isn't defined, go set it");
+            }
+
+            var names = Enumerable.Range(0, 1<<20).Select(x => tempNameForIndex(x, "temp"));
+
+            path = "";
+            foreach (var name in names) {
+                path = Path.Combine(di.FullName, name);
+
+                if (!File.Exists(path) && !Directory.Exists(path)) {
+                    break;
+                }
+            }
+
+            var thePath = path;
+            return Disposable.Create(() => File.Delete(thePath));
         }
 
         public static async Task DeleteDirectory(string directoryPath)

--- a/test/Squirrel.Tests.csproj
+++ b/test/Squirrel.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.0.99.9-build1021\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.0.99.9-build1021\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\packages\xunit.core.2.0.0-beta5-build2785\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0-beta5-build2785\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.core.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0-rc3-build1046\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc3-build1046\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,7 +13,7 @@
     <AssemblyName>Squirrel.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>76e21819</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>b2a8a210</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -73,18 +73,18 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.abstractions.2.0.0-beta5-build2785\lib\net35\xunit.abstractions.dll</HintPath>
+      <HintPath>..\packages\xunit.abstractions.2.0.0-rc3-build2880\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2785, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.assert, Version=2.0.0.2880, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\xunit.assert.2.0.0-beta5-build2785\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch10\xunit.assert.dll</HintPath>
+      <HintPath>..\packages\xunit.assert.2.0.0-rc3-build2880\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2785, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.core, Version=2.0.0.2880, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\xunit.core.2.0.0-beta5-build2785\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid\xunit.core.dll</HintPath>
+      <HintPath>..\packages\xunit.extensibility.core.2.0.0-rc3-build2880\lib\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.runner.utility, Version=2.0.0.2785, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.runner.utility.2.0.0-beta5-build2785\lib\net35\xunit.runner.utility.dll</HintPath>
+    <Reference Include="xunit.runner.utility.desktop">
+      <HintPath>..\packages\xunit.runner.utility.2.0.0-rc3-build2880\lib\net35\xunit.runner.utility.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -131,8 +131,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.core.2.0.0-beta5-build2785\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0-beta5-build2785\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.core.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.0.99.9-build1021\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.0.99.9-build1021\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0-rc3-build2880\build\portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc3-build1046\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0-rc3-build1046\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' != 'CIBuild|AnyCPU'">
     <PostBuildEvent>"$(SolutionDir).nuget\NuGet.exe" pack "$(ProjectPath)" -OutputDirectory "$(ProjectDir)$(OutDir)." -Properties Configuration=$(Configuration)</PostBuildEvent>

--- a/test/UtilityTests.cs
+++ b/test/UtilityTests.cs
@@ -28,6 +28,19 @@ namespace Squirrel.Tests.Core
             Console.WriteLine("Saved to " + path);
         }
 
+        [Theory]
+        [InlineData(10, 1)]
+        [InlineData(100, 1)]
+        [InlineData(0, 1)]
+        [InlineData(30000, 2)]
+        [InlineData(50000, 2)]
+        [InlineData(10000000, 3)]
+        public void TestTempNameGeneration(int index, int expectedLength)
+        {
+            string result = Utility.tempNameForIndex(index, "");
+            Assert.Equal(result.Length, expectedLength);
+        }
+
         [Fact]
         public void RemoveByteOrderMarkerIfPresent()
         {

--- a/test/packages.config
+++ b/test/packages.config
@@ -4,10 +4,11 @@
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Nuget.Core" version="2.8.3" targetFramework="net45" />
   <package id="Splat" version="1.5.1" targetFramework="net45" />
-  <package id="xunit" version="2.0.0-beta5-build2785" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0-beta5-build2785" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0-beta5-build2785" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0-beta5-build2785" targetFramework="net45" />
-  <package id="xunit.runner.utility" version="2.0.0-beta5-build2785" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="0.99.9-build1021" targetFramework="net45" />
+  <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.runner.utility" version="2.0.0-rc3-build2880" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.0-rc3-build1046" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
For various reasons (probably including old versions of Squirrel), a ton of people have their entire Temp folder full with files - `Path.GetTempFileName` will iterate through `tmp0000.tmp` => `tmpFFFF.tmp` and if all 65K files are taken, you're SOL. 

So instead, we'll make our own cooler, way better'er version, that has a 1M limit (and a different prefix, so hopefully we won't even come close to the original limit)