### PR TITLE
Remove unused applicationName field/ctor arg

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -22,11 +22,9 @@ namespace Squirrel
             readonly FrameworkVersion appFrameworkVersion = FrameworkVersion.Net45;
 
             readonly string rootAppDirectory;
-            readonly string applicationName;
 
-            public ApplyReleasesImpl(string applicationName, string rootAppDirectory)
+            public ApplyReleasesImpl(string rootAppDirectory)
             {
-                this.applicationName = applicationName;
                 this.rootAppDirectory = rootAppDirectory;
             }
 

--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -77,7 +77,7 @@ namespace Squirrel
 
         public async Task<string> ApplyReleases(UpdateInfo updateInfo, Action<int> progress = null)
         {
-            var applyReleases = new ApplyReleasesImpl(applicationName, rootAppDirectory);
+            var applyReleases = new ApplyReleasesImpl(rootAppDirectory);
             await acquireUpdateLock();
 
             return await applyReleases.ApplyReleases(updateInfo, false, false, progress);
@@ -88,7 +88,7 @@ namespace Squirrel
             var updateInfo = await CheckForUpdate();
             await DownloadReleases(updateInfo.ReleasesToApply);
 
-            var applyReleases = new ApplyReleasesImpl(applicationName, rootAppDirectory);
+            var applyReleases = new ApplyReleasesImpl(rootAppDirectory);
             await acquireUpdateLock();
 
             await applyReleases.ApplyReleases(updateInfo, silentInstall, true, progress);
@@ -96,7 +96,7 @@ namespace Squirrel
 
         public async Task FullUninstall()
         {
-            var applyReleases = new ApplyReleasesImpl(applicationName, rootAppDirectory);
+            var applyReleases = new ApplyReleasesImpl(rootAppDirectory);
             await acquireUpdateLock();
 
             await applyReleases.FullUninstall();
@@ -122,13 +122,13 @@ namespace Squirrel
 
         public void CreateShortcutsForExecutable(string exeName, ShortcutLocation locations, bool updateOnly)
         {
-            var installHelpers = new ApplyReleasesImpl(applicationName, rootAppDirectory);
+            var installHelpers = new ApplyReleasesImpl(rootAppDirectory);
             installHelpers.CreateShortcutsForExecutable(exeName, locations, updateOnly);
         }
 
         public void RemoveShortcutsForExecutable(string exeName, ShortcutLocation locations)
         {
-            var installHelpers = new ApplyReleasesImpl(applicationName, rootAppDirectory);
+            var installHelpers = new ApplyReleasesImpl(rootAppDirectory);
             installHelpers.RemoveShortcutsForExecutable(exeName, locations);
         }
 

--- a/test/ApplyReleasesTests.cs
+++ b/test/ApplyReleasesTests.cs
@@ -232,7 +232,7 @@ namespace Squirrel.Tests
                     "Squirrel.Core.1.1.0.0-full.nupkg",
                 }.ForEach(x => File.Copy(IntegrationTestHelper.GetPath("fixtures", x), Path.Combine(packagesDir, x)));
 
-                var fixture = new UpdateManager.ApplyReleasesImpl("theApp", appDir);
+                var fixture = new UpdateManager.ApplyReleasesImpl(appDir);
 
                 var baseEntry = ReleaseEntry.GenerateFromFile(Path.Combine(packagesDir, "Squirrel.Core.1.0.0.0-full.nupkg"));
                 var latestFullEntry = ReleaseEntry.GenerateFromFile(Path.Combine(packagesDir, "Squirrel.Core.1.1.0.0-full.nupkg"));
@@ -281,7 +281,7 @@ namespace Squirrel.Tests
                     "Squirrel.Core.1.2.0.0-full.nupkg",
                 }.ForEach(x => File.Copy(IntegrationTestHelper.GetPath("fixtures", x), Path.Combine(packagesDir, x)));
 
-                var fixture = new UpdateManager.ApplyReleasesImpl("theApp", appDir);
+                var fixture = new UpdateManager.ApplyReleasesImpl(appDir);
 
                 var baseEntry = ReleaseEntry.GenerateFromFile(Path.Combine(packagesDir, "Squirrel.Core.1.1.0.0-full.nupkg"));
                 var latestFullEntry = ReleaseEntry.GenerateFromFile(Path.Combine(packagesDir, "Squirrel.Core.1.2.0.0-full.nupkg"));
@@ -330,7 +330,7 @@ namespace Squirrel.Tests
                     "Squirrel.Core.1.3.0.0-full.nupkg",
                 }.ForEach(x => File.Copy(IntegrationTestHelper.GetPath("fixtures", x), Path.Combine(packagesDir, x)));
 
-                var fixture = new UpdateManager.ApplyReleasesImpl("theApp", appDir);
+                var fixture = new UpdateManager.ApplyReleasesImpl(appDir);
 
                 var baseEntry = ReleaseEntry.GenerateFromFile(Path.Combine(packagesDir, "Squirrel.Core.1.1.0.0-full.nupkg"));
                 var latestFullEntry = ReleaseEntry.GenerateFromFile(Path.Combine(packagesDir, "Squirrel.Core.1.3.0.0-full.nupkg"));
@@ -381,7 +381,7 @@ namespace Squirrel.Tests
                     "Squirrel.Core.1.1.0.0-full.nupkg",
                 }.ForEach(x => File.Copy(IntegrationTestHelper.GetPath("fixtures", x), Path.Combine(packagesDir, x)));
 
-                var fixture = new UpdateManager.ApplyReleasesImpl("theApp", appDir);
+                var fixture = new UpdateManager.ApplyReleasesImpl(appDir);
 
                 var baseEntry = ReleaseEntry.GenerateFromFile(Path.Combine(packagesDir, "Squirrel.Core.1.0.0.0-full.nupkg"));
                 var deltaEntry = ReleaseEntry.GenerateFromFile(Path.Combine(packagesDir, "Squirrel.Core.1.1.0.0-delta.nupkg"));
@@ -431,7 +431,7 @@ namespace Squirrel.Tests
                 }.ForEach(x => File.Copy(IntegrationTestHelper.GetPath("fixtures", x), Path.Combine(tempDir, "theApp", "packages", x)));
 
                 var urlDownloader = new FakeUrlDownloader();
-                var fixture = new UpdateManager.ApplyReleasesImpl("theApp", appDir);
+                var fixture = new UpdateManager.ApplyReleasesImpl(appDir);
 
                 var baseEntry = ReleaseEntry.GenerateFromFile(Path.Combine(tempDir, "theApp", "packages", "Squirrel.Core.1.0.0.0-full.nupkg"));
                 var deltaEntry = ReleaseEntry.GenerateFromFile(Path.Combine(tempDir, "theApp", "packages", "Squirrel.Core.1.1.0.0-delta.nupkg"));
@@ -458,7 +458,7 @@ namespace Squirrel.Tests
                     await mgr.FullInstall();
                 }
 
-                var fixture = new UpdateManager.ApplyReleasesImpl("theApp", Path.Combine(path, "theApp"));
+                var fixture = new UpdateManager.ApplyReleasesImpl(Path.Combine(path, "theApp"));
                 fixture.CreateShortcutsForExecutable("SquirrelAwareApp.exe", ShortcutLocation.Desktop | ShortcutLocation.StartMenu | ShortcutLocation.Startup | ShortcutLocation.AppRoot, false);
 
                 // NB: COM is Weird.

--- a/test/UpdateManagerTests.cs
+++ b/test/UpdateManagerTests.cs
@@ -69,7 +69,7 @@ namespace Squirrel.Tests
                         "Squirrel.Core.1.1.0.0-full.nupkg",
                     }.ForEach(x => File.Copy(IntegrationTestHelper.GetPath("fixtures", x), Path.Combine(tempDir, "theApp", "packages", x)));
 
-                    var fixture = new UpdateManager.ApplyReleasesImpl("theApp", appDir);
+                    var fixture = new UpdateManager.ApplyReleasesImpl(appDir);
 
                     await fixture.updateLocalReleasesFile();
 
@@ -132,7 +132,7 @@ namespace Squirrel.Tests
                         File.Copy(path, Path.Combine(remotePackages, x));
                     });
 
-                    var fixture = new UpdateManager.ApplyReleasesImpl("theApp", appDir);
+                    var fixture = new UpdateManager.ApplyReleasesImpl(appDir);
                         
                     // sync both release files
                     await fixture.updateLocalReleasesFile();
@@ -178,7 +178,7 @@ namespace Squirrel.Tests
                         File.Copy(path, Path.Combine(remotePackages, x));
                     });
 
-                    var fixture = new UpdateManager.ApplyReleasesImpl("theApp", appDir);
+                    var fixture = new UpdateManager.ApplyReleasesImpl(appDir);
 
                     // sync both release files
                     await fixture.updateLocalReleasesFile();
@@ -220,7 +220,7 @@ namespace Squirrel.Tests
                         File.Copy(path, Path.Combine(remotePackages, x));
                     });
 
-                    var fixture = new UpdateManager.ApplyReleasesImpl("theApp", appDir);
+                    var fixture = new UpdateManager.ApplyReleasesImpl(appDir);
 
                     // sync both release files
                     await fixture.updateLocalReleasesFile();


### PR DESCRIPTION
ApplyReleasesImpl has an unused field which does nothing, but does share a name with some method parameters.  This removes it