### PR TITLE
Install to ProgramData when LocalAppData is broken

### DIFF
--- a/src/Setup/Setup.vcxproj
+++ b/src/Setup/Setup.vcxproj
@@ -83,7 +83,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;secur32.lib</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>compat.manifest</AdditionalManifestFiles>
@@ -108,7 +108,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;secur32.lib</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>compat.manifest</AdditionalManifestFiles>
@@ -133,7 +133,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;secur32.lib</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>compat.manifest</AdditionalManifestFiles>

--- a/src/Setup/UpdateRunner.cpp
+++ b/src/Setup/UpdateRunner.cpp
@@ -140,7 +140,7 @@ int CUpdateRunner::ExtractUpdaterAndRun(wchar_t* lpCommandLine, bool useFallback
 	if (!useFallbackDir) {
 		SHGetFolderPath(NULL, CSIDL_LOCAL_APPDATA, NULL, SHGFP_TYPE_CURRENT, targetDir);
 	} else {
-		ExpandEnvironmentStrings(targetDir, L"%HOMEDRIVE%\\ProgramData", _countof(targetDir));
+		ExpandEnvironmentStrings(L"%HOMEDRIVE%\\ProgramData", targetDir, _countof(targetDir));
 
 		// NB: HOMEDRIVE may be unset or jacked up
 		if (targetDir[0] == L':') {

--- a/src/Setup/UpdateRunner.cpp
+++ b/src/Setup/UpdateRunner.cpp
@@ -141,6 +141,12 @@ int CUpdateRunner::ExtractUpdaterAndRun(wchar_t* lpCommandLine, bool useFallback
 		SHGetFolderPath(NULL, CSIDL_LOCAL_APPDATA, NULL, SHGFP_TYPE_CURRENT, targetDir);
 	} else {
 		ExpandEnvironmentStrings(targetDir, L"%HOMEDRIVE%\\ProgramData", _countof(targetDir));
+
+		// NB: HOMEDRIVE may be unset or jacked up
+		if (targetDir[0] == L':') {
+			wcscpy_s(targetDir, _countof(targetDir), L"C:\\ProgramData");
+		}
+
 		if (!CreateDirectory(targetDir, NULL) && GetLastError() != ERROR_ALREADY_EXISTS) {
 			wchar_t err[4096];
 			_swprintf_c(err, _countof(err), L"Unable to write to %s - IT policies may be restricting access to this folder", targetDir);

--- a/src/Setup/UpdateRunner.cpp
+++ b/src/Setup/UpdateRunner.cpp
@@ -140,12 +140,14 @@ int CUpdateRunner::ExtractUpdaterAndRun(wchar_t* lpCommandLine, bool useFallback
 	if (!useFallbackDir) {
 		SHGetFolderPath(NULL, CSIDL_LOCAL_APPDATA, NULL, SHGFP_TYPE_CURRENT, targetDir);
 	} else {
-		wchar_t username[64];
+		wchar_t username[512];
+		wchar_t uid[128];
 		wchar_t appDataDir[MAX_PATH];
 		ULONG unameSize = _countof(username);
 
 		SHGetFolderPath(NULL, CSIDL_COMMON_APPDATA, NULL, SHGFP_TYPE_CURRENT, appDataDir);
-		GetUserNameEx(NameUniqueId, username, &unameSize);
+		GetUserName(username, &unameSize);
+		DWORD lastError = GetLastError();
 
 		_swprintf_c(targetDir, _countof(targetDir), L"%s\\%s", appDataDir, username);
 

--- a/src/Setup/UpdateRunner.h
+++ b/src/Setup/UpdateRunner.h
@@ -7,5 +7,5 @@ private:
 public:
 	static HRESULT AreWeUACElevated();
 	static HRESULT ShellExecuteFromExplorer(LPWSTR pszFile, LPWSTR pszParameters);
-	static int ExtractUpdaterAndRun(wchar_t* lpCommandLine);
+	static int ExtractUpdaterAndRun(wchar_t* lpCommandLine, bool useFallbackDir);
 };

--- a/src/Setup/stdafx.h
+++ b/src/Setup/stdafx.h
@@ -8,6 +8,7 @@
 #include "targetver.h"
 
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+#define SECURITY_WIN32
 
 // Windows Header Files:
 #include <windows.h>
@@ -28,6 +29,7 @@
 #include <atlwin.h>
 
 #include <windows.h>
+#include <security.h>
 #include <shlobj.h>
 #include <exdisp.h>
 #include <shlwapi.h>

--- a/src/Setup/winmain.cpp
+++ b/src/Setup/winmain.cpp
@@ -21,7 +21,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 	hr = _Module.Init(NULL, hInstance);
 
 	CString cmdLine(lpCmdLine);
-	bool isQuiet = (cmdLine.Find(L"/quiet") >= 0);
+	bool isQuiet = (cmdLine.Find(L"-s") >= 0);
 
 	if (!CFxHelper::IsDotNet45OrHigherInstalled()) {
 		hr = CFxHelper::InstallDotNetFramework(isQuiet);
@@ -51,7 +51,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		goto out;
 	}
 
-	exitCode = CUpdateRunner::ExtractUpdaterAndRun(lpCmdLine);
+	exitCode = CUpdateRunner::ExtractUpdaterAndRun(lpCmdLine, false);
 
 out:
 	_Module.Term();

--- a/src/Squirrel/DeltaPackage.cs
+++ b/src/Squirrel/DeltaPackage.cs
@@ -20,6 +20,12 @@ namespace Squirrel
 
     public class DeltaPackageBuilder : IEnableLogger, IDeltaPackageBuilder
     {
+        readonly string localAppDirectory;
+        public DeltaPackageBuilder(string localAppDataOverride = null)
+        {
+            this.localAppDirectory = localAppDataOverride;
+        }
+
         public ReleasePackage CreateDeltaPackage(ReleasePackage basePackage, ReleasePackage newPackage, string outputFile)
         {
             Contract.Requires(basePackage != null);
@@ -48,8 +54,8 @@ namespace Squirrel
             string baseTempPath = null;
             string tempPath = null;
 
-            using (Utility.WithTempDirectory(out baseTempPath))
-            using (Utility.WithTempDirectory(out tempPath)) {
+            using (Utility.WithTempDirectory(out baseTempPath, null))
+            using (Utility.WithTempDirectory(out tempPath, null)) {
                 var baseTempInfo = new DirectoryInfo(baseTempPath);
                 var tempInfo = new DirectoryInfo(tempPath);
 
@@ -89,8 +95,8 @@ namespace Squirrel
             string workingPath;
             string deltaPath;
 
-            using (Utility.WithTempDirectory(out deltaPath))
-            using (Utility.WithTempDirectory(out workingPath)) {
+            using (Utility.WithTempDirectory(out deltaPath, localAppDirectory))
+            using (Utility.WithTempDirectory(out workingPath, localAppDirectory)) {
                 var fz = new FastZip();
                 fz.ExtractZip(deltaPackage.InputPackageFile, deltaPath, null);
                 fz.ExtractZip(basePackage.InputPackageFile, workingPath, null);
@@ -187,7 +193,7 @@ namespace Squirrel
             var finalTarget = Path.Combine(workingDirectory, Regex.Replace(relativeFilePath, @".diff$", ""));
 
             var tempTargetFile = default(string);
-            Utility.WithTempFile(out tempTargetFile);
+            Utility.WithTempFile(out tempTargetFile, localAppDirectory);
 
             try {
                 // NB: Zero-length diffs indicate the file hasn't actually changed

--- a/src/Squirrel/ReleaseEntry.cs
+++ b/src/Squirrel/ReleaseEntry.cs
@@ -192,7 +192,7 @@ namespace Squirrel
             // place
             var entries = entriesQueue.ToList();
             var tempFile = default(string);
-            Utility.WithTempFile(out tempFile);
+            Utility.WithTempFile(out tempFile, releasePackagesDir);
 
             try {
                 using (var of = File.OpenWrite(tempFile)) {

--- a/src/Squirrel/ReleasePackage.cs
+++ b/src/Squirrel/ReleasePackage.cs
@@ -126,7 +126,7 @@ namespace Squirrel
 
             string tempPath = null;
 
-            using (Utility.WithTempDirectory(out tempPath)) {
+            using (Utility.WithTempDirectory(out tempPath, null)) {
                 var tempDir = new DirectoryInfo(tempPath);
                 var fz = new FastZip();
 

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -316,7 +316,7 @@ namespace Squirrel
                     var basePkg = new ReleasePackage(Path.Combine(rootAppDirectory, "packages", currentVersion.Filename));
                     var deltaPkg = new ReleasePackage(Path.Combine(rootAppDirectory, "packages", releasesToApply.First().Filename));
 
-                    var deltaBuilder = new DeltaPackageBuilder();
+                    var deltaBuilder = new DeltaPackageBuilder(Directory.GetParent(this.rootAppDirectory).FullName);
 
                     return deltaBuilder.ApplyDeltaPackage(basePkg, deltaPkg,
                         Regex.Replace(deltaPkg.InputPackageFile, @"-delta.nupkg$", ".nupkg", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant));

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -364,7 +364,7 @@ namespace Squirrel
                 if (us != null && Path.GetFileName(us.Location).Equals("update.exe", StringComparison.OrdinalIgnoreCase)) {
                     var appName = targetDir.Parent.Name;
 
-                    Process.Start(newSquirrel, "--updateSelf=" + appName);
+                    Process.Start(newSquirrel, "--updateSelf=" + us.Location);
                     return;
                 }
 

--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -48,15 +48,7 @@ namespace Squirrel
                 return;
             }
 
-            // Determine the rootAppDirectory in such a way so that Portable 
-            // Apps are more likely to work
-            var entry = Assembly.GetEntryAssembly();
-            if (entry != null) {
-                rootDirectory = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(entry.Location), "..", ".."));
-            }
-
             this.rootAppDirectory = Path.Combine(rootDirectory ?? GetLocalAppDataDirectory(), applicationName);
-
         }
 
         public async Task<UpdateInfo> CheckForUpdate(bool ignoreDeltaUpdates = false, Action<int> progress = null)

--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -243,9 +243,31 @@ namespace Squirrel
             return target.FullName;
         }
 
-        static string getLocalAppDataDirectory()
+        static string getLocalAppDataDirectory(string assemblyLocation = null)
         {
-            return Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            // Try to divine our our own install location via reading tea leaves
+            //
+            // * We're Update.exe, running in the app's install folder
+            // * We're Update.exe, running on initial install from SquirrelTemp
+            // * We're a C# EXE with Squirrel linked in
+
+            var assembly = Assembly.GetEntryAssembly();
+            if (assemblyLocation == null && assembly == null) {
+                // dunno lol
+                return Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            }
+
+            assemblyLocation = assemblyLocation ?? assembly.Location;
+
+            if (Path.GetFileName(assemblyLocation).Equals("update.exe", StringComparison.OrdinalIgnoreCase)) {
+                // NB: Both the "SquirrelTemp" case and the "App's folder" case 
+                // mean that the root app dir is one up
+                var oneFolderUpFromAppFolder = Path.Combine(Path.GetDirectoryName(assemblyLocation), "..");
+                return Path.GetFullPath(oneFolderUpFromAppFolder);
+            }
+
+            var twoFoldersUpFromAppFolder = Path.Combine(Path.GetDirectoryName(assemblyLocation), "..\\..");
+            return Path.GetFullPath(twoFoldersUpFromAppFolder);
         }
     }
 }

--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -152,6 +152,10 @@ namespace Squirrel
             get { return rootAppDirectory; }
         }
 
+        public bool IsInstalledApp {
+            get { return Assembly.GetExecutingAssembly().Location.StartsWith(RootAppDirectory, StringComparison.OrdinalIgnoreCase); }
+        }
+
         public void Dispose()
         {
             var disp = Interlocked.Exchange(ref updateLock, null);

--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -246,10 +246,10 @@ namespace Squirrel
             return prefix + directoryChars.Value[index % directoryChars.Value.Length] + tempNameForIndex(index / directoryChars.Value.Length, "");
         }
 
-        public static DirectoryInfo GetTempDirectory()
+        public static DirectoryInfo GetTempDirectory(string localAppDirectory)
         {
             var tempDir = Environment.GetEnvironmentVariable("SQUIRREL_TEMP");
-            tempDir = tempDir ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SquirrelTemp");
+            tempDir = tempDir ?? Path.Combine(localAppDirectory ?? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SquirrelTemp");
 
             var di = new DirectoryInfo(tempDir);
             if (!di.Exists) di.Create();
@@ -257,9 +257,9 @@ namespace Squirrel
             return di;
         }
 
-        public static IDisposable WithTempDirectory(out string path)
+        public static IDisposable WithTempDirectory(out string path, string localAppDirectory = null)
         {
-            var di = GetTempDirectory();
+            var di = GetTempDirectory(localAppDirectory);
             var tempDir = default(DirectoryInfo);
 
             var names = Enumerable.Range(0, 1<<20).Select(x => tempNameForIndex(x, "temp"));
@@ -279,9 +279,9 @@ namespace Squirrel
             return Disposable.Create(() => Task.Run(async () => await DeleteDirectory(tempDir.FullName)).Wait());
         }
 
-        public static IDisposable WithTempFile(out string path)
+        public static IDisposable WithTempFile(out string path, string localAppDirectory = null)
         {
-            var di = GetTempDirectory();
+            var di = GetTempDirectory(localAppDirectory);
             var names = Enumerable.Range(0, 1<<20).Select(x => tempNameForIndex(x, "temp"));
 
             path = "";

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -179,6 +179,7 @@ namespace Squirrel.Update
                 .First().PackageName;
 
             using (var mgr = new UpdateManager(sourceDirectory, ourAppName, FrameworkVersion.Net45)) {
+                this.Log().Info("About to install to: " + mgr.RootAppDirectory);
                 Directory.CreateDirectory(mgr.RootAppDirectory);
 
                 var updateTarget = Path.Combine(mgr.RootAppDirectory, "Update.exe");
@@ -198,12 +199,9 @@ namespace Squirrel.Update
 
             this.Log().Info("Starting update, downloading from " + updateUrl);
 
-            // NB: Always basing the rootAppDirectory relative to ours allows us to create Portable
-            // Applications
-            var ourDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "..");
-
-            using (var mgr = new UpdateManager(updateUrl, appName, FrameworkVersion.Net45, ourDir)) {
+            using (var mgr = new UpdateManager(updateUrl, appName, FrameworkVersion.Net45)) {
                 bool ignoreDeltaUpdates = false;
+                this.Log().Info("About to update to: " + mgr.RootAppDirectory);
 
             retry:
                 try {
@@ -243,12 +241,8 @@ namespace Squirrel.Update
         {
             appName = appName ?? getAppNameFromDirectory();
 
-            // NB: Always basing the rootAppDirectory relative to ours allows us to create Portable
-            // Applications
-            var ourDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "..");
-
             this.Log().Info("Fetching update information, downloading from " + updateUrl);
-            using (var mgr = new UpdateManager(updateUrl, appName, FrameworkVersion.Net45, ourDir)) {
+            using (var mgr = new UpdateManager(updateUrl, appName, FrameworkVersion.Net45)) {
                 var updateInfo = await mgr.CheckForUpdate(progress: x => Console.WriteLine(x / 3));
                 await mgr.DownloadReleases(updateInfo.ReleasesToApply, x => Console.WriteLine(33 + x / 3));
 
@@ -271,12 +265,8 @@ namespace Squirrel.Update
         {
             this.Log().Info("Starting uninstall for app: " + appName);
 
-            // NB: Always basing the rootAppDirectory relative to ours allows us to create Portable
-            // Applications
-            var ourDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "..");
-
             appName = appName ?? getAppNameFromDirectory();
-            using (var mgr = new UpdateManager("", appName, FrameworkVersion.Net45, ourDir)) {
+            using (var mgr = new UpdateManager("", appName, FrameworkVersion.Net45)) {
                 await mgr.FullUninstall();
                 mgr.RemoveUninstallerRegistryEntry();
             }
@@ -404,11 +394,7 @@ namespace Squirrel.Update
             var defaultLocations = ShortcutLocation.StartMenu | ShortcutLocation.Desktop;
             var locations = parseShortcutLocations(shortcutArgs);
 
-            // NB: Always basing the rootAppDirectory relative to ours allows us to create Portable
-            // Applications
-            var ourDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "..");
-
-            using (var mgr = new UpdateManager("", appName, FrameworkVersion.Net45, ourDir)) {
+            using (var mgr = new UpdateManager("", appName, FrameworkVersion.Net45)) {
                 mgr.CreateShortcutsForExecutable(exeName, locations ?? defaultLocations, false);
             }
         }
@@ -424,11 +410,7 @@ namespace Squirrel.Update
             var defaultLocations = ShortcutLocation.StartMenu | ShortcutLocation.Desktop;
             var locations = parseShortcutLocations(shortcutArgs);
 
-            // NB: Always basing the rootAppDirectory relative to ours allows us to create Portable
-            // Applications
-            var ourDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "..");
-
-            using (var mgr = new UpdateManager("", appName, FrameworkVersion.Net45, ourDir)) {
+            using (var mgr = new UpdateManager("", appName, FrameworkVersion.Net45)) {
                 mgr.RemoveShortcutsForExecutable(exeName, locations ?? defaultLocations);
             }
         }

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -342,7 +342,7 @@ namespace Squirrel.Update
 
                 var prev = ReleaseEntry.GetPreviousRelease(previousReleases, rp, targetDir);
                 if (prev != null) {
-                    var deltaBuilder = new DeltaPackageBuilder();
+                    var deltaBuilder = new DeltaPackageBuilder(null);
 
                     var dp = deltaBuilder.CreateDeltaPackage(prev, rp,
                         Path.Combine(di.FullName, rp.SuggestedReleaseFileName.Replace("full", "delta")));
@@ -505,7 +505,7 @@ namespace Squirrel.Update
             string tempPath;
 
             this.Log().Info("Building embedded zip file for Setup.exe");
-            using (Utility.WithTempDirectory(out tempPath)) {
+            using (Utility.WithTempDirectory(out tempPath, null)) {
                 this.ErrorIfThrows(() => {
                     File.Copy(Assembly.GetEntryAssembly().Location, Path.Combine(tempPath, "Update.exe"));
                     File.Copy(fullPackage, Path.Combine(tempPath, Path.GetFileName(fullPackage)));


### PR DESCRIPTION
For a dizzying array of reasons, installing anything to `%LocalAppData%` simply doesn't work, or throws bizarre errors. It turns out though, that since nobody knows what the hell to do with `C:\ProgramData`, nobody looks there either. When installations fail to `%LocalAppData%`, we're gonna fall back to `C:\ProgramData\$PackageName`. On Windows 7 where `C:\ProgramData` doesn't exist, we'll just make it.

This PR also adds an `IsInstalledApp` property on UpdateManager which lets you tell if the application is currently installed.

## Pay Attention To This!

If your application currently is hard-coded to look in `%LocalAppData%` for stuff, this PR will break you (well technically, these users were never able to install in the first place, but now they will be able to and now you're gonna see weirdness). Instead, use UpdateManager's `RootAppDirectory` property, or do all of your operations relative to `Assembly.GetExecutingAssembly().Location`.

## TODO

- [x] Remove our use of LocalAppData in Update.exe
- [x] Rig Setup to fall back to ProgramData
- [x] Remove LocalAppData from Squirrel
- [x] Make sure this works everywhere