### PR TITLE
Update.exe: take OrderByDescending to find the latest version of the app directory

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -428,7 +428,7 @@ namespace Squirrel.Update
                 File.ReadAllText(Utility.LocalReleaseFileForAppDir(appDir), Encoding.UTF8));
 
             var latestAppDir = releases
-                .OrderBy(x => x.Version)
+                .OrderByDescending(x => x.Version)
                 .Select(x => Utility.AppDirForRelease(appDir, x))
                 .FirstOrDefault(x => Directory.Exists(x));
 


### PR DESCRIPTION
`update.exe --processStart MyApplicationName.exe` should search for the latest app directory and then start the exe in there. Currently, the method uses `OrderBy` to order the directories by version and `FirstOrDefault` to get the latest app directory.
I think this is wrong, as this will get you the oldest version and therefore the oldest app directory. Use `OrderByDescending` to fix this.