### PR TITLE
NuGet.core updated to 2.8.5

### DIFF
--- a/src/Squirrel/Squirrel.csproj
+++ b/src/Squirrel/Squirrel.csproj
@@ -63,9 +63,9 @@
     <Reference Include="Mono.Cecil.Rocks">
       <HintPath>..\..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.50926.602, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Core, Version=2.8.60318.667, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Nuget.Core.2.8.3\lib\net40-Client\NuGet.Core.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Core.2.8.5\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
     <Reference Include="Splat, Version=1.5.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Squirrel/packages.config
+++ b/src/Squirrel/packages.config
@@ -3,6 +3,6 @@
   <package id="DeltaCompressionDotNet" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net45" />
-  <package id="Nuget.Core" version="2.8.3" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
   <package id="Splat" version="1.5.1" targetFramework="net45" />
 </packages>

--- a/src/SyncReleases/SyncReleases.csproj
+++ b/src/SyncReleases/SyncReleases.csproj
@@ -39,9 +39,9 @@
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.50926.602, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Core, Version=2.8.60318.667, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Nuget.Core.2.8.3\lib\net40-Client\NuGet.Core.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Core.2.8.5\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
     <Reference Include="Octokit, Version=0.5.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -66,7 +66,9 @@
     <Compile Include="Mono.Options\Options.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SyncImplementations.cs" />
+    <Compile Include="SyncImplementations.cs">
+      <SubType>Component</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/src/SyncReleases/packages.config
+++ b/src/SyncReleases/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Mono.Options" version="1.1" targetFramework="net45" />
-  <package id="Nuget.Core" version="2.8.3" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
   <package id="Octokit" version="0.5.2" targetFramework="net45" />
   <package id="Splat" version="1.5.1" targetFramework="net45" />
 </packages>

--- a/src/Update/Update.csproj
+++ b/src/Update/Update.csproj
@@ -59,9 +59,9 @@
     <Reference Include="Mono.Cecil.Rocks">
       <HintPath>..\..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.50926.602, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Core, Version=2.8.60318.667, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Nuget.Core.2.8.3\lib\net40-Client\NuGet.Core.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Core.2.8.5\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/Update/packages.config
+++ b/src/Update/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net45" />
   <package id="Mono.Options" version="1.1" targetFramework="net45" />
-  <package id="Nuget.Core" version="2.8.3" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
   <package id="SimpleJson" version="0.38.0" targetFramework="net45" />
   <package id="Splat" version="1.5.1" targetFramework="net45" />
   <package id="WpfAnimatedGif" version="1.4.9" targetFramework="net45" />

--- a/test/Squirrel.Tests.csproj
+++ b/test/Squirrel.Tests.csproj
@@ -57,9 +57,9 @@
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.50926.602, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Core, Version=2.8.60318.667, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Nuget.Core.2.8.3\lib\net40-Client\NuGet.Core.dll</HintPath>
+      <HintPath>..\packages\NuGet.Core.2.8.5\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
     <Reference Include="Splat, Version=1.5.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/test/packages.config
+++ b/test/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="DeltaCompressionDotNet" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="Nuget.Core" version="2.8.3" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
   <package id="Splat" version="1.5.1" targetFramework="net45" />
   <package id="xunit" version="2.0.0-rc3-build2880" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0-rc3-build2880" targetFramework="net45" />


### PR DESCRIPTION
While fixing  #321 I see that Squirrel (update.exe) was not the reading the binding redirection in my App.config for Nuget.Core 2.8.5, but still looking for the 2.8.3 version.

The Squirrel Nuget installs Nuget.Core 2.8.5 but the Squirrel source code uses Nuget.Core 2.8.3. Thas why I do belive that is still reading that old version that is not in the Bin folder.

This PR simply update Nuget.Core to 2.8.5 version in the source code to match the version used in Squirrel Nuget.

For fix #321 I had to downgrade the Nuget.Core version and now it works, the PR purposed did not fix it.