### PR TITLE
Bring back bsdiff as a fallback

### DIFF
--- a/src/Squirrel/ContentType.cs
+++ b/src/Squirrel/ContentType.cs
@@ -10,6 +10,7 @@ namespace Squirrel
         {
             var elements = new [] {
                 Tuple.Create("Default", "diff", "application/octet" ),
+                Tuple.Create("Default", "bsdiff", "application/octet" ),
                 Tuple.Create("Default", "exe", "application/octet" ),
                 Tuple.Create("Default", "dll", "application/octet" ),
                 Tuple.Create("Default", "shasum", "text/plain" ),

--- a/src/Squirrel/DeltaPackage.cs
+++ b/src/Squirrel/DeltaPackage.cs
@@ -189,7 +189,7 @@ namespace Squirrel
                     // versions which don't understand bsdiff will fail out
                     // until they get upgraded, instead of seeing the missing
                     // file and just removing it.
-                    File.WriteAllText(targetFile + ".diff", "1");
+                    File.WriteAllText(targetFile.FullName + ".diff", "1");
                 } catch (Exception ex) {
                     this.Log().WarnException(String.Format("We really couldn't create a delta for {0}", targetFile.Name), ex);
                     return;

--- a/src/Squirrel/DeltaPackage.cs
+++ b/src/Squirrel/DeltaPackage.cs
@@ -214,12 +214,19 @@ namespace Squirrel
                 }
 
                 if (relativeFilePath.EndsWith(".diff", StringComparison.InvariantCultureIgnoreCase)) {
-                    this.Log().Info("Applying Diff to {0}", relativeFilePath);
+                    this.Log().Info("Applying MSDiff to {0}", relativeFilePath);
                     var msDelta = new MsDeltaCompression();
                     msDelta.ApplyDelta(inputFile, finalTarget, tempTargetFile);
 
                     verifyPatchedFile(relativeFilePath, inputFile, tempTargetFile);
-                   
+                } else if (relativeFilePath.EndsWith(".bsdiff", StringComparison.InvariantCultureIgnoreCase)) {
+                    using (var of = File.OpenWrite(tempTargetFile))
+                    using (var inf = File.OpenRead(finalTarget)) {
+                        this.Log().Info("Applying BSDiff to {0}", relativeFilePath);
+                        BinaryPatchUtility.Apply(inf, () => File.OpenRead(inputFile), of);
+                    }
+
+                    verifyPatchedFile(relativeFilePath, inputFile, tempTargetFile);
                 } else {
                     using (var of = File.OpenWrite(tempTargetFile))
                     using (var inf = File.OpenRead(inputFile)) {

--- a/src/Squirrel/DeltaPackage.cs
+++ b/src/Squirrel/DeltaPackage.cs
@@ -189,7 +189,7 @@ namespace Squirrel
                     // versions which don't understand bsdiff will fail out
                     // until they get upgraded, instead of seeing the missing
                     // file and just removing it.
-                    File.WriteAllText(targetFile + ".diff", " ");
+                    File.WriteAllText(targetFile + ".diff", "1");
                 } catch (Exception ex) {
                     this.Log().WarnException(String.Format("We really couldn't create a delta for {0}", targetFile.Name), ex);
                     return;

--- a/src/Squirrel/ReleasePackage.cs
+++ b/src/Squirrel/ReleasePackage.cs
@@ -101,7 +101,6 @@ namespace Squirrel
             // ever expect one entry here (crash hard otherwise)
             var frameworks = package.GetSupportedFrameworks();
             if (frameworks.Count() > 1) {
-
                 var platforms = frameworks
                     .Aggregate(new StringBuilder(), (sb, f) => sb.Append(f.ToString() + "; "));
 
@@ -109,7 +108,6 @@ namespace Squirrel
                     "The input package file {0} targets multiple platforms - {1} - and cannot be transformed into a release package.", InputPackageFile, platforms));
 
             } else if (!frameworks.Any()) {
-
                 throw new InvalidOperationException(String.Format(
                     "The input package file {0} targets no platform and cannot be transformed into a release package.", InputPackageFile));
             }

--- a/src/Squirrel/Squirrel.csproj
+++ b/src/Squirrel/Squirrel.csproj
@@ -87,6 +87,7 @@
     <Compile Include="..\SolutionAssemblyInfo.cs">
       <Link>Properties\SolutionAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="BinaryPatchUtility.cs" />
     <Compile Include="ContentType.cs" />
     <Compile Include="DeltaPackage.cs" />
     <Compile Include="EnumerableExtensions.cs" />


### PR DESCRIPTION
MSDelta can't handle certain files (usually non-executable files, like ASAR archives. If MSDelta fails, we should fall back to bsdiff instead.