### PR TITLE
Make download progress reach 100% reliably

### DIFF
--- a/src/Squirrel/UpdateManager.DownloadReleases.cs
+++ b/src/Squirrel/UpdateManager.DownloadReleases.cs
@@ -40,6 +40,16 @@ namespace Squirrel
                                 progress((int)Math.Round(current += component));
                             }
                         });
+                        // With a lot of small updates, and since notifications are only sent every half second
+                        // for each one, we can easily miss half or more of the progress on each download.
+                        // To make sure we eventually get to 100% of the whole process, we need to update
+                        // progress (and especially the total in current) to indicate that this one is complete.
+                        lock (progress)
+                        {
+                            current -= component;
+                            component = toIncrement;
+                            progress((int)Math.Round(current += component));
+                        }
                     });
                 } else {
                     // From Disk


### PR DESCRIPTION
FileDownloader.DownloadFile ignores progress notifications received less than 500ms after the previous notification. This means that a random amount of progress, up to half a second per file, is lost from the cumulative total. We've seen updates report as little as 40% complete by the time they were entirely done. This commit updates the progress correctly at the end of each download.