### PR TITLE
Use class member applicationName variable instead of local in UpdateManager's constructor.

### DIFF
--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -41,11 +41,11 @@ namespace Squirrel
             this.urlDownloader = urlDownloader ?? new FileDownloader();
 
             if (rootDirectory != null) {
-                this.rootAppDirectory = Path.Combine(rootDirectory, applicationName);
+                this.rootAppDirectory = Path.Combine(rootDirectory, this.applicationName);
                 return;
             }
 
-            this.rootAppDirectory = Path.Combine(rootDirectory ?? GetLocalAppDataDirectory(), applicationName);
+            this.rootAppDirectory = Path.Combine(rootDirectory ?? GetLocalAppDataDirectory(), this.applicationName);
         }
 
         public async Task<UpdateInfo> CheckForUpdate(bool ignoreDeltaUpdates = false, Action<int> progress = null)


### PR DESCRIPTION
I keep getting an exception from Path.Combine after updating to 0.99 if applicationName parameter is null, as suggested since it's now optional.

I guess this is just a small oversight and the local applicationName is used to find the rootAppDirectory, even though the class member applicationName is correctly set beforehand.