### PR TITLE
Repair ILRepack command to produce correct assembly name

### DIFF
--- a/src/Squirrel/Squirrel.csproj
+++ b/src/Squirrel/Squirrel.csproj
@@ -105,10 +105,12 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PostBuildEvent>cd "$(TargetDir)"
-"$(SolutionDir)packages\ILRepack.1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) Mono.Cecil.dll NuGet.Core.dll
-del "$(TargetFileName)"
-ren "$(TargetFileName).tmp" "$(TargetFileName)"</PostBuildEvent>
+    <PostBuildEvent>
+        cd "$(TargetDir)"
+        ren "$(TargetFileName)" "$(TargetFileName).tmp.dll"
+        "$(SolutionDir)packages\ILRepack.1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName) $(TargetFileName).tmp.dll Mono.Cecil.dll NuGet.Core.dll
+        del "$(TargetFileName).tmp.dll"
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
/out: command must have desired assembly name as file name before extension

(The old version produced a squirrel with squirrel.dll as the assembly name, and then when code tries to load squirrel.dll, the loader looks for squirrell.dll.dll and fails to find it, and the client program won't run.)