### PR TITLE
Display "Open Setup Log" button when there IS an install failure log

### DIFF
--- a/src/Setup/UpdateRunner.cpp
+++ b/src/Setup/UpdateRunner.cpp
@@ -13,7 +13,7 @@ void CUpdateRunner::DisplayErrorMessage(CString& errorMessage, wchar_t* logFile)
 	};
 
 	// TODO: Something about contacting support?
-	if (logFile != NULL) {
+	if (logFile == NULL) {
 		dlg.SetButtons(&buttons[1], 1, 1);
 	} else {
 		dlg.SetButtons(buttons, 2, 1);


### PR DESCRIPTION
The old version shows the "Open Setup Log" button
exactly when it should be hidden (because there is none)