### PR TITLE
Fork NuGet so we can fix its tragic bugs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/nuget"]
+	path = vendor/nuget
+	url = https://github.com/paulcbetts/NuGet

--- a/Squirrel.sln
+++ b/Squirrel.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Squirrel", "src\Squirrel\Squirrel.csproj", "{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}"
 EndProject
@@ -24,12 +24,20 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionLevel", "SolutionLe
 		src\Squirrel.nuspec = src\Squirrel.nuspec
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "vendor\nuget\src\Core\Core.csproj", "{F879F274-EFA0-4157-8404-33A19B4E6AEC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		CIBuild|Any CPU = CIBuild|Any CPU
 		CIBuild|Mixed Platforms = CIBuild|Mixed Platforms
+		Coverage|Any CPU = Coverage|Any CPU
+		Coverage|Mixed Platforms = Coverage|Mixed Platforms
 		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Mono Debug|Any CPU = Mono Debug|Any CPU
+		Mono Debug|Mixed Platforms = Mono Debug|Mixed Platforms
+		Mono Release|Any CPU = Mono Release|Any CPU
+		Mono Release|Mixed Platforms = Mono Release|Mixed Platforms
 		Release|Any CPU = Release|Any CPU
 		Release|Mixed Platforms = Release|Mixed Platforms
 	EndGlobalSection
@@ -38,10 +46,22 @@ Global
 		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.CIBuild|Any CPU.Build.0 = CIBuild|Any CPU
 		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.CIBuild|Mixed Platforms.ActiveCfg = CIBuild|Any CPU
 		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.CIBuild|Mixed Platforms.Build.0 = CIBuild|Any CPU
+		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Coverage|Any CPU.ActiveCfg = CIBuild|Any CPU
+		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Coverage|Any CPU.Build.0 = CIBuild|Any CPU
+		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Coverage|Mixed Platforms.ActiveCfg = CIBuild|Any CPU
+		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Coverage|Mixed Platforms.Build.0 = CIBuild|Any CPU
 		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Mono Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Mono Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Mono Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Mono Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Mono Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Mono Release|Any CPU.Build.0 = Release|Any CPU
+		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Mono Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Mono Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1436E22A-FE3C-4D68-9A85-9E74DF2E6A92}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -50,10 +70,22 @@ Global
 		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.CIBuild|Any CPU.Build.0 = CIBuild|Any CPU
 		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.CIBuild|Mixed Platforms.ActiveCfg = CIBuild|Any CPU
 		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.CIBuild|Mixed Platforms.Build.0 = CIBuild|Any CPU
+		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Coverage|Any CPU.ActiveCfg = CIBuild|Any CPU
+		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Coverage|Any CPU.Build.0 = CIBuild|Any CPU
+		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Coverage|Mixed Platforms.ActiveCfg = CIBuild|Any CPU
+		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Coverage|Mixed Platforms.Build.0 = CIBuild|Any CPU
 		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Mono Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Mono Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Mono Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Mono Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Mono Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Mono Release|Any CPU.Build.0 = Release|Any CPU
+		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Mono Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Mono Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{98AEB048-E27D-42F4-9440-505B7F78BAFD}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -62,10 +94,22 @@ Global
 		{C1D40624-A484-438A-B846-052F321C89D1}.CIBuild|Any CPU.Build.0 = CIBuild|Win32
 		{C1D40624-A484-438A-B846-052F321C89D1}.CIBuild|Mixed Platforms.ActiveCfg = CIBuild|Win32
 		{C1D40624-A484-438A-B846-052F321C89D1}.CIBuild|Mixed Platforms.Build.0 = CIBuild|Win32
+		{C1D40624-A484-438A-B846-052F321C89D1}.Coverage|Any CPU.ActiveCfg = Release|Win32
+		{C1D40624-A484-438A-B846-052F321C89D1}.Coverage|Any CPU.Build.0 = Release|Win32
+		{C1D40624-A484-438A-B846-052F321C89D1}.Coverage|Mixed Platforms.ActiveCfg = CIBuild|Win32
+		{C1D40624-A484-438A-B846-052F321C89D1}.Coverage|Mixed Platforms.Build.0 = CIBuild|Win32
 		{C1D40624-A484-438A-B846-052F321C89D1}.Debug|Any CPU.ActiveCfg = Debug|Win32
 		{C1D40624-A484-438A-B846-052F321C89D1}.Debug|Any CPU.Build.0 = Debug|Win32
 		{C1D40624-A484-438A-B846-052F321C89D1}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
 		{C1D40624-A484-438A-B846-052F321C89D1}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{C1D40624-A484-438A-B846-052F321C89D1}.Mono Debug|Any CPU.ActiveCfg = Release|Win32
+		{C1D40624-A484-438A-B846-052F321C89D1}.Mono Debug|Any CPU.Build.0 = Release|Win32
+		{C1D40624-A484-438A-B846-052F321C89D1}.Mono Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{C1D40624-A484-438A-B846-052F321C89D1}.Mono Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{C1D40624-A484-438A-B846-052F321C89D1}.Mono Release|Any CPU.ActiveCfg = Release|Win32
+		{C1D40624-A484-438A-B846-052F321C89D1}.Mono Release|Any CPU.Build.0 = Release|Win32
+		{C1D40624-A484-438A-B846-052F321C89D1}.Mono Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{C1D40624-A484-438A-B846-052F321C89D1}.Mono Release|Mixed Platforms.Build.0 = Release|Win32
 		{C1D40624-A484-438A-B846-052F321C89D1}.Release|Any CPU.ActiveCfg = Release|Win32
 		{C1D40624-A484-438A-B846-052F321C89D1}.Release|Any CPU.Build.0 = Release|Win32
 		{C1D40624-A484-438A-B846-052F321C89D1}.Release|Mixed Platforms.ActiveCfg = Release|Win32
@@ -74,10 +118,22 @@ Global
 		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.CIBuild|Any CPU.Build.0 = Release|Any CPU
 		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.CIBuild|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.CIBuild|Mixed Platforms.Build.0 = Release|Any CPU
+		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Coverage|Any CPU.ActiveCfg = Debug|Any CPU
+		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Coverage|Any CPU.Build.0 = Debug|Any CPU
+		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Coverage|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Coverage|Mixed Platforms.Build.0 = Debug|Any CPU
 		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Mono Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Mono Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Mono Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Mono Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Mono Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Mono Release|Any CPU.Build.0 = Release|Any CPU
+		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Mono Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Mono Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1EEBACBC-6982-4696-BD4E-899ED0AC6CD2}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -86,14 +142,50 @@ Global
 		{EB521191-1EBF-4D06-8541-ED192E2EE378}.CIBuild|Any CPU.Build.0 = Release|Any CPU
 		{EB521191-1EBF-4D06-8541-ED192E2EE378}.CIBuild|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{EB521191-1EBF-4D06-8541-ED192E2EE378}.CIBuild|Mixed Platforms.Build.0 = Release|Any CPU
+		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Coverage|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Coverage|Any CPU.Build.0 = Debug|Any CPU
+		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Coverage|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Coverage|Mixed Platforms.Build.0 = Debug|Any CPU
 		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Mono Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Mono Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Mono Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Mono Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Mono Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Mono Release|Any CPU.Build.0 = Release|Any CPU
+		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Mono Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Mono Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Release|Any CPU.Build.0 = Release|Any CPU
 		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{EB521191-1EBF-4D06-8541-ED192E2EE378}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.CIBuild|Any CPU.ActiveCfg = Coverage|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.CIBuild|Any CPU.Build.0 = Coverage|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.CIBuild|Mixed Platforms.ActiveCfg = Coverage|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.CIBuild|Mixed Platforms.Build.0 = Coverage|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Coverage|Any CPU.ActiveCfg = Coverage|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Coverage|Any CPU.Build.0 = Coverage|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Coverage|Mixed Platforms.ActiveCfg = Coverage|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Coverage|Mixed Platforms.Build.0 = Coverage|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Mono Debug|Any CPU.ActiveCfg = Mono Debug|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Mono Debug|Any CPU.Build.0 = Mono Debug|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Mono Debug|Mixed Platforms.ActiveCfg = Mono Debug|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Mono Debug|Mixed Platforms.Build.0 = Mono Debug|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Mono Release|Any CPU.ActiveCfg = Mono Release|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Mono Release|Any CPU.Build.0 = Mono Release|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Mono Release|Mixed Platforms.ActiveCfg = Mono Release|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Mono Release|Mixed Platforms.Build.0 = Mono Release|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F879F274-EFA0-4157-8404-33A19B4E6AEC}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Squirrel/Squirrel.csproj
+++ b/src/Squirrel/Squirrel.csproj
@@ -55,10 +55,6 @@
       <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.60318.667, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Core.2.8.5\lib\net40-Client\NuGet.Core.dll</HintPath>
-    </Reference>
     <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Splat.1.6.2\lib\Net45\Splat.dll</HintPath>
       <Private>True</Private>
@@ -105,15 +101,13 @@
     <Compile Include="UpdateManager.ApplyReleases.cs" />
     <Compile Include="UpdateManager.InstallHelpers.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\vendor\nuget\src\Core\Core.csproj">
+      <Project>{f879f274-efa0-4157-8404-33a19b4e6aec}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-      cd "$(TargetDir)"
-      ren "$(TargetFileName)" "$(TargetFileName).tmp.dll"
-      "$(SolutionDir)packages\ILRepack.1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName) $(TargetFileName).tmp.dll Mono.Cecil.dll NuGet.Core.dll
-      del "$(TargetFileName).tmp.dll"
-    </PostBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Squirrel/packages.config
+++ b/src/Squirrel/packages.config
@@ -3,6 +3,5 @@
   <package id="DeltaCompressionDotNet" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
   <package id="Splat" version="1.6.2" targetFramework="net45" />
 </packages>

--- a/src/SyncReleases/SyncReleases.csproj
+++ b/src/SyncReleases/SyncReleases.csproj
@@ -39,10 +39,6 @@
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.60318.667, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Core.2.8.5\lib\net40-Client\NuGet.Core.dll</HintPath>
-    </Reference>
     <Reference Include="Octokit, Version=0.10.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Octokit.0.10.0\lib\net45\Octokit.dll</HintPath>
       <Private>True</Private>
@@ -67,15 +63,17 @@
     <Compile Include="Mono.Options\Options.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SyncImplementations.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="SyncImplementations.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\vendor\nuget\src\Core\Core.csproj">
+      <Project>{f879f274-efa0-4157-8404-33a19b4e6aec}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Squirrel\Squirrel.csproj">
       <Project>{1436e22a-fe3c-4d68-9a85-9e74df2e6a92}</Project>
       <Name>Squirrel</Name>
@@ -84,7 +82,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PostBuildEvent>cd "$(TargetDir)"
-"$(SolutionDir)packages\ILRepack.1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) ICSharpCode.SharpZipLib.dll Microsoft.Web.XmlTransform.dll Splat.dll Squirrel.dll Octokit.dll
+"$(SolutionDir)packages\ILRepack.1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) ICSharpCode.SharpZipLib.dll Microsoft.Web.XmlTransform.dll Splat.dll Squirrel.dll Octokit.dll NuGet.Squirrel.dll
 del "$(TargetFileName)"
 ren "$(TargetFileName).tmp" "$(TargetFileName)"</PostBuildEvent>
   </PropertyGroup>

--- a/src/SyncReleases/packages.config
+++ b/src/SyncReleases/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Mono.Options" version="1.1" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
   <package id="Octokit" version="0.10.0" targetFramework="net45" />
   <package id="Splat" version="1.6.2" targetFramework="net45" />
 </packages>

--- a/src/Update/Update.csproj
+++ b/src/Update/Update.csproj
@@ -65,8 +65,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
-    <Reference Include="WpfAnimatedGif, Version=1.4.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WpfAnimatedGif.1.4.12\lib\net\WpfAnimatedGif.dll</HintPath>
+    <Reference Include="WpfAnimatedGif, Version=1.4.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WpfAnimatedGif.1.4.13\lib\net\WpfAnimatedGif.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/Update/Update.csproj
+++ b/src/Update/Update.csproj
@@ -114,7 +114,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PostBuildEvent>cd "$(TargetDir)"
-"$(SolutionDir)packages\ILRepack.1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) WpfAnimatedGif.dll ICSharpCode.SharpZipLib.dll Microsoft.Web.XmlTransform.dll Splat.dll DeltaCompressionDotNet.dll DeltaCompressionDotNet.MsDelta.dll Squirrel.dll NuGet.Squirrel.dll
+"$(SolutionDir)packages\ILRepack.1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) WpfAnimatedGif.dll ICSharpCode.SharpZipLib.dll Microsoft.Web.XmlTransform.dll Splat.dll DeltaCompressionDotNet.dll DeltaCompressionDotNet.MsDelta.dll Squirrel.dll NuGet.Squirrel.dll Mono.Cecil.dll
 del "$(TargetFileName)"
 ren "$(TargetFileName).tmp" "$(TargetFileName)"</PostBuildEvent>
   </PropertyGroup>

--- a/src/Update/Update.csproj
+++ b/src/Update/Update.csproj
@@ -88,6 +88,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\vendor\nuget\src\Core\Core.csproj">
+      <Project>{f879f274-efa0-4157-8404-33a19b4e6aec}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Squirrel\Squirrel.csproj">
       <Project>{1436e22a-fe3c-4d68-9a85-9e74df2e6a92}</Project>
       <Name>Squirrel</Name>
@@ -110,7 +114,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PostBuildEvent>cd "$(TargetDir)"
-"$(SolutionDir)packages\ILRepack.1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) WpfAnimatedGif.dll ICSharpCode.SharpZipLib.dll Microsoft.Web.XmlTransform.dll Splat.dll DeltaCompressionDotNet.dll DeltaCompressionDotNet.MsDelta.dll Squirrel.dll
+"$(SolutionDir)packages\ILRepack.1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) WpfAnimatedGif.dll ICSharpCode.SharpZipLib.dll Microsoft.Web.XmlTransform.dll Splat.dll DeltaCompressionDotNet.dll DeltaCompressionDotNet.MsDelta.dll Squirrel.dll NuGet.Squirrel.dll
 del "$(TargetFileName)"
 ren "$(TargetFileName).tmp" "$(TargetFileName)"</PostBuildEvent>
   </PropertyGroup>

--- a/src/Update/packages.config
+++ b/src/Update/packages.config
@@ -4,7 +4,6 @@
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
   <package id="Mono.Options" version="1.1" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
   <package id="SimpleJson" version="0.38.0" targetFramework="net45" />
   <package id="Splat" version="1.6.2" targetFramework="net45" />
   <package id="WpfAnimatedGif" version="1.4.12" targetFramework="net45" />

--- a/src/Update/packages.config
+++ b/src/Update/packages.config
@@ -6,5 +6,5 @@
   <package id="Mono.Options" version="1.1" targetFramework="net45" />
   <package id="SimpleJson" version="0.38.0" targetFramework="net45" />
   <package id="Splat" version="1.6.2" targetFramework="net45" />
-  <package id="WpfAnimatedGif" version="1.4.12" targetFramework="net45" />
+  <package id="WpfAnimatedGif" version="1.4.13" targetFramework="net45" />
 </packages>

--- a/test/Squirrel.Tests.csproj
+++ b/test/Squirrel.Tests.csproj
@@ -113,6 +113,10 @@
       <Project>{1436e22a-fe3c-4d68-9a85-9e74df2e6a92}</Project>
       <Name>Squirrel</Name>
     </ProjectReference>
+    <ProjectReference Include="..\vendor\nuget\src\Core\Core.csproj">
+      <Project>{f879f274-efa0-4157-8404-33a19b4e6aec}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/test/Squirrel.Tests.csproj
+++ b/test/Squirrel.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -13,7 +13,8 @@
     <AssemblyName>Squirrel.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>c0014311</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -130,7 +131,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' != 'CIBuild|AnyCPU'">
     <PostBuildEvent>"$(SolutionDir).nuget\NuGet.exe" pack "$(ProjectPath)" -OutputDirectory "$(ProjectDir)$(OutDir)." -Properties Configuration=$(Configuration)</PostBuildEvent>

--- a/test/packages.config
+++ b/test/packages.config
@@ -9,5 +9,5 @@
   <package id="xunit.core" version="2.0.0" targetFramework="net45" />
   <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
   <package id="xunit.runner.utility" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.1" targetFramework="net45" />
 </packages>

--- a/test/packages.config
+++ b/test/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="DeltaCompressionDotNet" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
   <package id="Splat" version="1.6.2" targetFramework="net45" />
   <package id="xunit" version="2.0.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
This PR vendors the NuGet source so we can change it at-will, mostly to fix the OutOfMemoryException when loading content as well as let Squirrel.dll be stepped through in the debugger again. 

## TODO:

- [x] Vendor NuGet, get everything working again
- [x] Fix OutOfMemoryException