### PR TITLE
Reworked steps order, and image inclusion

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,10 +2,6 @@
 
 * `Install-Package squirrel.windows`, or grab the binaries from the Releases section
 
-* Use NuGet Package Explorer (or any other way) to create a NuGet package for your app. Make sure that package doesn't have any dependencies. Here's a good example package:
-
-* Open the NuGet Package Console, and type `Squirrel --releasify path/to/the/nuget/package.nupkg`
-
 * In your app at an appropriate time (not at startup, don't interrupt the user's work), call:
 
 ```cs
@@ -17,9 +13,14 @@ using (var mgr = new UpdateManager("https://path/to/my/update/folder"))
 }
 ```
 
+* Use NuGet Package Explorer (or any other way) to create a NuGet package for your app. Make sure that package doesn't have any dependencies. Here's a good example package:
+
+![](http://cl.ly/image/261D2x2X1e3G/content#png) 
+
+* Open the NuGet Package Console, and type `Squirrel --releasify path/to/the/nuget/package.nupkg`
+
 You should have a folder called `Releases` with three files in it. Publish those all to S3 in the same folder and you've now got an installer.
 
-![](http://cl.ly/image/261D2x2X1e3G/content#png)
 
 ## BETA: Some hacky notes that will go away soon
 


### PR DESCRIPTION
The image describing the package was not at the right place.
The step providing code to check for update, should be done before packaging the files.