### PR TITLE
Set default/optional LegalCopyright for Setup.exe from nuspec/nupkg

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -581,6 +581,7 @@ namespace Squirrel.Update
         {
             var verStrings = new Dictionary<string, string>() {
                 { "CompanyName", package.Authors.First() },
+                { "LegalCopyright", package.Copyright ?? "Copyright © 2015 " + package.Authors.First() },
                 { "FileDescription", package.Summary ?? package.Description ?? "Installer for " + package.Id },
                 { "ProductName", package.Description ?? package.Summary ?? package.Id },
             };

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -581,7 +581,7 @@ namespace Squirrel.Update
         {
             var verStrings = new Dictionary<string, string>() {
                 { "CompanyName", package.Authors.First() },
-                { "LegalCopyright", package.Copyright ?? "Copyright © 2015 " + package.Authors.First() },
+                { "LegalCopyright", package.Copyright ?? "Copyright © " + DateTime.Now.Year.ToString() + " " + package.Authors.First() },
                 { "FileDescription", package.Summary ?? package.Description ?? "Installer for " + package.Id },
                 { "ProductName", package.Description ?? package.Summary ?? package.Id },
             };


### PR DESCRIPTION
This seems obsolete:
- "LegalCopyright", "Copyright (C) 2014"... https://github.com/Squirrel/Squirrel.Windows/blob/master/src/Setup/Setup.rc#L99

Maybe lets set default new copyright with first owner or get it from nuspec/nupkg.