### PR TITLE
Allow prerelease versions when parsing release entries

### DIFF
--- a/src/Squirrel/IUpdateManager.cs
+++ b/src/Squirrel/IUpdateManager.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32;
 using Splat;
+using NuGet;
 
 namespace Squirrel
 {
@@ -84,7 +85,7 @@ namespace Squirrel
         /// executable</param>
         /// <returns>The running version, or null if this is not a Squirrel
         /// installed app (i.e. you're running from VS)</returns>
-        Version CurrentlyInstalledVersion(string executable = null);
+        SemanticVersion CurrentlyInstalledVersion(string executable = null);
 
         /// <summary>
         /// Creates an entry in Programs and Features based on the currently 

--- a/src/Squirrel/ReleaseEntry.cs
+++ b/src/Squirrel/ReleaseEntry.cs
@@ -20,7 +20,7 @@ namespace Squirrel
         long Filesize { get; }
         bool IsDelta { get; }
         string EntryAsString { get; }
-        Version Version { get; }
+        SemanticVersion Version { get; }
         string PackageName { get; }
 
         string GetReleaseNotes(string packageDirectory);
@@ -52,7 +52,7 @@ namespace Squirrel
         }
 
         [IgnoreDataMember]
-        public Version Version { get { return Filename.ToVersion(); } }
+        public SemanticVersion Version { get { return Filename.ToSemanticVersion(); } }
 
         [IgnoreDataMember]
         public string PackageName {
@@ -223,7 +223,7 @@ namespace Squirrel
 
             return releaseEntries
                 .Where(x => x.IsDelta == false)
-                .Where(x => x.Version < package.ToVersion())
+                .Where(x => x.Version < package.ToSemanticVersion())
                 .OrderByDescending(x => x.Version)
                 .Select(x => new ReleasePackage(Path.Combine(targetDir, x.Filename), true))
                 .FirstOrDefault();

--- a/src/Squirrel/ReleaseExtensions.cs
+++ b/src/Squirrel/ReleaseExtensions.cs
@@ -10,8 +10,8 @@ namespace Squirrel
 {
     public static class VersionExtensions
     {
-        private static readonly Regex _suffixRegex = new Regex(@"(-full|-delta)?\.nupkg$", RegexOptions.Compiled);
-        private static readonly Regex _versionRegex = new Regex(@"\d+(\.\d+){0,3}(-[a-z][0-9a-z-]*)?$", RegexOptions.Compiled);
+        static readonly Regex _suffixRegex = new Regex(@"(-full|-delta)?\.nupkg$", RegexOptions.Compiled);
+        static readonly Regex _versionRegex = new Regex(@"\d+(\.\d+){0,3}(-[a-z][0-9a-z-]*)?$", RegexOptions.Compiled);
 
         public static SemanticVersion ToSemanticVersion(this IReleasePackage package)
         {

--- a/src/Squirrel/ReleasePackage.cs
+++ b/src/Squirrel/ReleasePackage.cs
@@ -84,7 +84,7 @@ namespace Squirrel
             }
         }
 
-        public Version Version { get { return InputPackageFile.ToVersion(); } }
+        public SemanticVersion Version { get { return InputPackageFile.ToSemanticVersion(); } }
 
         public string CreateReleasePackage(string outputFile, string packagesRootDir = null, Func<string, string> releaseNotesProcessor = null, Action<string> contentsPostProcessHook = null)
         {

--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -129,7 +129,7 @@ namespace Squirrel
             installHelpers.RemoveShortcutsForExecutable(exeName, locations);
         }
 
-        public Version CurrentlyInstalledVersion(string executable = null)
+        public SemanticVersion CurrentlyInstalledVersion(string executable = null)
         {
             executable = executable ??
                 Path.GetDirectoryName(typeof(UpdateManager).Assembly.Location);
@@ -142,7 +142,7 @@ namespace Squirrel
                 .FirstOrDefault(x => x.StartsWith("app-", StringComparison.OrdinalIgnoreCase));
 
             if (appDirName == null) return null;
-            return appDirName.ToVersion();
+            return appDirName.ToSemanticVersion();
         }
 
         public string ApplicationName {

--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
+using NuGet;
 
 namespace Squirrel
 {
@@ -349,6 +350,11 @@ namespace Squirrel
         public static string AppDirForRelease(string rootAppDirectory, ReleaseEntry entry)
         {
             return Path.Combine(rootAppDirectory, "app-" + entry.Version.ToString());
+        }
+
+        public static string AppDirForVersion(string rootAppDirectory, SemanticVersion version)
+        {
+            return Path.Combine(rootAppDirectory, "app-" + version.ToString());
         }
 
         public static string PackageDirectoryForAppDir(string rootAppDirectory) 

--- a/test/ReleaseEntryTests.cs
+++ b/test/ReleaseEntryTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Squirrel;
 using Squirrel.Tests.TestHelpers;
 using Xunit;
+using NuGet;
 
 namespace Squirrel.Tests.Core
 {
@@ -58,15 +59,30 @@ namespace Squirrel.Tests.Core
         }
 
         [Theory]
-        [InlineData("94689fede03fed7ab59c24337673a27837f0c3ec  MyCoolApp-1.0.nupkg  1004502", 1, 0)]
-        [InlineData("3a2eadd15dd984e4559f2b4d790ec8badaeb6a39  MyCoolApp-1.1.nupkg  1040561", 1, 1)]
-        [InlineData("14db31d2647c6d2284882a2e101924a9c409ee67  MyCoolApp-1.1-delta.nupkg  80396", 1, 1)]
-        public void ParseVersionTest(string releaseEntry, int expectedMajor, int expectedMinor)
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.nupkg                  123", 1, 2, 0, 0, "", false)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2-full.nupkg             123", 1, 2, 0, 0, "", false)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2-delta.nupkg            123", 1, 2, 0, 0, "", true)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2-beta1.nupkg            123", 1, 2, 0, 0, "beta1", false)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2-beta1-full.nupkg       123", 1, 2, 0, 0, "beta1", false)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2-beta1-delta.nupkg      123", 1, 2, 0, 0, "beta1", true)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.3.nupkg                123", 1, 2, 3, 0, "", false)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.3-full.nupkg           123", 1, 2, 3, 0, "", false)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.3-delta.nupkg          123", 1, 2, 3, 0, "", true)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.3-beta1.nupkg          123", 1, 2, 3, 0, "beta1", false)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.3-beta1-full.nupkg     123", 1, 2, 3, 0, "beta1", false)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.3-beta1-delta.nupkg    123", 1, 2, 3, 0, "beta1", true)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.3.4.nupkg              123", 1, 2, 3, 4, "", false)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.3.4-full.nupkg         123", 1, 2, 3, 4, "", false)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.3.4-delta.nupkg        123", 1, 2, 3, 4, "", true)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.3.4-beta1.nupkg        123", 1, 2, 3, 4, "beta1", false)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.3.4-beta1-full.nupkg   123", 1, 2, 3, 4, "beta1", false)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.3.4-beta1-delta.nupkg  123", 1, 2, 3, 4, "beta1", true)]
+        public void ParseVersionTest(string releaseEntry, int major, int minor, int patch, int revision, string prerelease, bool isDelta)
         {
             var fixture = ReleaseEntry.ParseReleaseEntry(releaseEntry);
 
-            Assert.Equal(expectedMajor, fixture.Version.Major);
-            Assert.Equal(expectedMinor, fixture.Version.Minor);
+            Assert.Equal(new SemanticVersion(new Version(major, minor, patch, revision), prerelease), fixture.Version);
+            Assert.Equal(isDelta, fixture.IsDelta);
         }
 
         [Fact]
@@ -114,7 +130,7 @@ namespace Squirrel.Tests.Core
         [Fact]
         public void WhenMultipleReleaseMatchesReturnEarlierResult()
         {
-            var expected = new Version("1.7.5");
+            var expected = new SemanticVersion("1.7.5-beta");
             var package = new ReleasePackage("Espera-1.7.6-beta.nupkg");
 
             var releaseEntries = new[] {
@@ -133,7 +149,7 @@ namespace Squirrel.Tests.Core
         [Fact]
         public void WhenMultipleReleasesFoundReturnPreviousVersion()
         {
-            var expected = new Version("1.7.6");
+            var expected = new SemanticVersion("1.7.6-beta");
             var input = new ReleasePackage("Espera-1.7.7-beta.nupkg");
 
             var releaseEntries = new[] {
@@ -152,7 +168,7 @@ namespace Squirrel.Tests.Core
         [Fact]
         public void WhenMultipleReleasesFoundInOtherOrderReturnPreviousVersion()
         {
-            var expected = new Version("1.7.6");
+            var expected = new SemanticVersion("1.7.6-beta");
             var input = new ReleasePackage("Espera-1.7.7-beta.nupkg");
 
             var releaseEntries = new[] {
@@ -172,9 +188,9 @@ namespace Squirrel.Tests.Core
         public void WhenReleasesAreOutOfOrderSortByVersion()
         {
             var path = Path.GetTempFileName();
-            var firstVersion = new Version("1.0.0");
-            var secondVersion = new Version("1.1.0");
-            var thirdVersion = new Version("1.2.0");
+            var firstVersion = new SemanticVersion("1.0.0");
+            var secondVersion = new SemanticVersion("1.1.0");
+            var thirdVersion = new SemanticVersion("1.2.0");
 
             var releaseEntries = new[] {
                 ReleaseEntry.ParseReleaseEntry(MockReleaseEntry("Espera-1.2.0-delta.nupkg")),

--- a/test/UpdateManagerTests.cs
+++ b/test/UpdateManagerTests.cs
@@ -10,6 +10,7 @@ using Squirrel;
 using Squirrel.Tests.TestHelpers;
 using Xunit;
 using System.Net;
+using NuGet;
 
 namespace Squirrel.Tests
 {
@@ -294,7 +295,7 @@ namespace Squirrel.Tests
             public void CurrentlyInstalledVersionTests(string input, string expectedVersion)
             {
                 input = Environment.ExpandEnvironmentVariables(input);
-                var expected = expectedVersion != null ? new Version(expectedVersion) : default(Version);
+                var expected = expectedVersion != null ? new SemanticVersion(expectedVersion) : default(SemanticVersion);
 
                 using (var fixture = new UpdateManager("http://lol", "theApp")) {
                     Assert.Equal(expected, fixture.CurrentlyInstalledVersion(input));


### PR DESCRIPTION
Fixes https://github.com/Squirrel/Squirrel.Windows/issues/449
Fixes https://github.com/Squirrel/Squirrel.Windows/issues/93

@paulcbetts  I'm opening this now so that you can :gun: it down sooner rather than later.

#### Overview

My strategy here is to avoid changing the format of `RELEASES`. The `-delta` and `-full` suffixes are still used to denote delta vs full packages, but semver pre-release strings are *also* allowed.

Unlike @GeertvanHorrik's proposed solution, I'm just relying on `NuGet.SemanticVersion` and its built-in ordering relation (prerelease versions are sorted alphabetically). No hard-coded orderings of specific prerelease strings.

#### Status

* AFAICT, there are twenty tests failing on `master`, and the same twenty fail against this branch.
* I haven't done any manual testing yet. I'll test some scenarios using Atom if you think this approach is viable.