### PR TITLE
Handle query strings in target URLs

### DIFF
--- a/src/Squirrel/Squirrel.csproj
+++ b/src/Squirrel/Squirrel.csproj
@@ -66,6 +66,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />

--- a/src/Squirrel/UpdateManager.CheckForUpdates.cs
+++ b/src/Squirrel/UpdateManager.CheckForUpdates.cs
@@ -62,16 +62,17 @@ namespace Squirrel
                 retry:
 
                     try {
-                        var url = String.Format("{0}/{1}", updateUrlOrPath, "RELEASES");
-                        if (latestLocalRelease != null) { 
-                            url = String.Format("{0}/RELEASES?id={1}&localVersion={2}&arch={3}", 
-                                updateUrlOrPath, 
-                                Uri.EscapeUriString(latestLocalRelease.PackageName), 
-                                Uri.EscapeUriString(latestLocalRelease.Version.ToString()),
-                                Environment.Is64BitOperatingSystem ? "amd64" : "x86");
+                        var uri = Utility.AppendPathToUri(new Uri(updateUrlOrPath), "RELEASES");
+                        if (latestLocalRelease != null) {
+                            uri = Utility.AddQueryParamsToUri(uri, new Dictionary<string, string>
+                            {
+                                { "id", latestLocalRelease.PackageName },
+                                { "localVersion", latestLocalRelease.Version.ToString() },
+                                { "arch", Environment.Is64BitOperatingSystem ? "amd64" : "x86" }
+                            });
                         }
 
-                        var data = await urlDownloader.DownloadUrl(url);
+                        var data = await urlDownloader.DownloadUrl(uri.ToString());
                         releaseFile = Encoding.UTF8.GetString(data);
                     } catch (WebException ex) {
                         this.Log().InfoException("Download resulted in WebException (returning blank release list)", ex);

--- a/src/Squirrel/UpdateManager.DownloadReleases.cs
+++ b/src/Squirrel/UpdateManager.DownloadReleases.cs
@@ -64,15 +64,13 @@ namespace Squirrel
 
             Task downloadRelease(string updateBaseUrl, ReleaseEntry releaseEntry, IFileDownloader urlDownloader, string targetFile, Action<int> progress)
             {
-                if (!updateBaseUrl.EndsWith("/")) {
-                    updateBaseUrl += '/';
-                }
+                var baseUri = Utility.EnsureTrailingSlash(new Uri(updateBaseUrl));
 
                 var releaseEntryUrl = releaseEntry.BaseUrl + releaseEntry.Filename;
                 if (!String.IsNullOrEmpty(releaseEntry.Query)) {
                     releaseEntryUrl += releaseEntry.Query;
                 }
-                var sourceFileUrl = new Uri(new Uri(updateBaseUrl), releaseEntryUrl).AbsoluteUri;
+                var sourceFileUrl = new Uri(baseUri, releaseEntryUrl).AbsoluteUri;
                 File.Delete(targetFile);
 
                 return urlDownloader.DownloadFile(sourceFileUrl, targetFile, progress);

--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -408,6 +408,34 @@ namespace Squirrel
             return uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps;
         }
 
+        public static Uri AppendPathToUri(Uri uri, string path)
+        {
+            var builder = new UriBuilder(uri);
+            if (!builder.Path.EndsWith("/"))
+            {
+                builder.Path += "/";
+            }
+            builder.Path += path;
+            return builder.Uri;
+        }
+
+        public static Uri EnsureTrailingSlash(Uri uri)
+        {
+            return AppendPathToUri(uri, "");
+        }
+
+        public static Uri AddQueryParamsToUri(Uri uri, IEnumerable<KeyValuePair<string, string>> newQuery)
+        {
+            var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
+            foreach (var entry in newQuery)
+            {
+                query[entry.Key] = entry.Value;
+            }
+            var builder = new UriBuilder(uri);
+            builder.Query = query.ToString();
+            return builder.Uri;
+        }
+
         public static void DeleteFileHarder(string path, bool ignoreIfFails = false)
         {
             try {

--- a/src/SyncReleases/SyncImplementations.cs
+++ b/src/SyncReleases/SyncImplementations.cs
@@ -14,7 +14,7 @@ namespace SyncReleases
     {
         public static async Task SyncRemoteReleases(Uri targetUri, DirectoryInfo releasesDir)
         {
-            var releasesUri = new Uri(targetUri + "/RELEASES");
+            var releasesUri = Utility.AppendPathToUri(targetUri, "RELEASES");
             var releasesIndex = await retryAsync(3, () => downloadReleasesIndex(releasesUri));
             File.WriteAllText(Path.Combine(releasesDir.FullName, "RELEASES"), releasesIndex);
 
@@ -24,7 +24,7 @@ namespace SyncReleases
                 .Take(5)
                 .Select(x => new {
                     LocalPath = Path.Combine(releasesDir.FullName, x.Filename),
-                    RemoteUrl = new Uri(targetUri + "/" + x.Filename)
+                    RemoteUrl = new Uri(Utility.EnsureTrailingSlash(targetUri), x.BaseUrl + x.Filename)
                  });
 
             foreach (var releaseToDownload in releasesToDownload) {
@@ -89,9 +89,8 @@ namespace SyncReleases
             ReleaseEntry.WriteReleaseFile(entries, Path.Combine(releaseDirectoryInfo.FullName, "RELEASES"));
         }
 
-        static async Task<string> downloadReleasesIndex(Uri repoUrl)
+        static async Task<string> downloadReleasesIndex(Uri uri)
         {
-            var uri = new Uri(repoUrl, "RELEASES");
             Console.WriteLine("Trying to download RELEASES index from {0}", uri);
 
             using (HttpClient client = new HttpClient()) {


### PR DESCRIPTION
Fixes #132 

This allows the following commands to handle URLs with query parameters
* `SyncReleases.exe --url=<URL>`
* `Update.exe --download=<URL>`
* `Update.exe --update=<URL>`

#### Testing
I temporarily published a beta release of Atom so that the `atom.io` redirects to that release's `RELEASES` asset when it gets a request for `/api/updates/RELEASES?version=1.1.0-beta0`.

* [x] Run `SyncReleases.exe --url=https://atom.io/api/updates?version=1.1.0-beta0` and verify that the correct `RELEASES` file is used.

  * Before: Fails with `System.Net.Http.HttpRequestException: Response status code does not indicate success: 404`
  * After: Works

* [x] Run `Update.exe --download=https://atom.io/api/updates?version=1.1.0-beta0` and verify that the correct release entries are returned.

  * Before: Fails with `System.Exception: Remote release File is empty or corrupted`
  * After: Works

* [x] Run `Update.exe --update` and verify that the app updates to the correct version.

  * Before: Fails with `System.Exception: Remote release File is empty or corrupted`
  * After: Updates from Atom 1.0.19 to 1.1.0-beta1
