### PR TITLE
Fallback to exe icon if iconUrl empty

### DIFF
--- a/src/Squirrel/UpdateManager.InstallHelpers.cs
+++ b/src/Squirrel/UpdateManager.InstallHelpers.cs
@@ -37,7 +37,7 @@ namespace Squirrel
                 // Download the icon and PNG => ICO it. If this doesn't work, who cares
                 var pkgPath = Path.Combine(rootAppDirectory, "packages", latest.Filename);
                 var zp = new ZipPackage(pkgPath);
-                    
+
                 var targetPng = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
                 var targetIco = Path.Combine(rootAppDirectory, "app.ico");
 
@@ -51,7 +51,7 @@ namespace Squirrel
 
                 if (zp.IconUrl != null && !File.Exists(targetIco)) {
                     try {
-                        using (var wc = Utility.CreateWebClient()) { 
+                        using (var wc = Utility.CreateWebClient()) {
                             await wc.DownloadFileTaskAsync(zp.IconUrl, targetPng);
                             using (var fs = new FileStream(targetIco, FileMode.Create)) {
                                 if (zp.IconUrl.AbsolutePath.EndsWith("ico")) {
@@ -72,7 +72,13 @@ namespace Squirrel
                     } finally {
                         File.Delete(targetPng);
                     }
+                } else {
+                    var exe = Directory.GetFiles(Path.Combine(rootAppDirectory, "app-" + latest.Version), "*.exe")
+                        .FirstOrDefault();
+                    if (!String.IsNullOrEmpty(exe))
+                        key.SetValue("DisplayIcon", Path.GetFullPath(exe) + ",0", RegistryValueKind.String);
                 }
+
 
                 var stringsToWrite = new[] {
                     new { Key = "DisplayName", Value = zp.Title ?? zp.Description ?? zp.Summary },


### PR DESCRIPTION
In many cases it is impossible to know where setup will be hosted, so it is impossible to know icon url beforehand
Often setup contains single exe file so is reasonable to set uninstall icon to exe icon