### PR TITLE
GitHub enterprise support

### DIFF
--- a/src/Squirrel/UpdateManager.Factory.cs
+++ b/src/Squirrel/UpdateManager.Factory.cs
@@ -40,7 +40,7 @@ namespace Squirrel
             var repoUri = new Uri(repoUrl);
             var userAgent = new ProductInfoHeaderValue("Squirrel", Assembly.GetExecutingAssembly().GetName().Version.ToString());
 
-            if (repoUri.Segments.Count() != 3) {
+            if (repoUri.Segments.Length != 3) {
                 throw new Exception("Repo URL must be to the root URL of the repo e.g. https://github.com/myuser/myrepo");
             }
 

--- a/src/Squirrel/UpdateManager.Factory.cs
+++ b/src/Squirrel/UpdateManager.Factory.cs
@@ -14,8 +14,6 @@ namespace Squirrel
 {
     public sealed partial class UpdateManager
     {
-        const string gitHubUrl = "https://api.github.com";
-
         [DataContract]
         public class Release
         {
@@ -44,14 +42,29 @@ namespace Squirrel
                 throw new Exception("Repo URL must be to the root URL of the repo e.g. https://github.com/myuser/myrepo");
             }
 
-            var releasesApiBuilder = new StringBuilder("/repos")
+            var releasesApiBuilder = new StringBuilder("repos")
                 .Append(repoUri.AbsolutePath)
                 .Append("/releases");
 
             if (!string.IsNullOrWhiteSpace(accessToken))
                 releasesApiBuilder.Append("?access_token=").Append(accessToken);
+            
+            Uri baseAddress;
 
-            using (var client = new HttpClient() { BaseAddress = new Uri(gitHubUrl) }) {
+            if (repoUri.Host.EndsWith("github.com", StringComparison.OrdinalIgnoreCase)) {
+                baseAddress = new Uri("https://api.github.com/");
+            } else {
+                // if it's not github.com, it's probably an Enterprise server
+                // now the problem with Enterprise is that the API doesn't come prefixed
+                // it comes suffixed
+                // so the API path of http://internal.github.server.local API location is
+                // http://interal.github.server.local/api/v3. 
+                baseAddress = new Uri(string.Format("{0}{1}{2}/api/v3/", repoUri.Scheme, Uri.SchemeDelimiter, repoUri.Host));
+            }
+
+            // above ^^ notice the end slashes for the baseAddress, explained here: http://stackoverflow.com/a/23438417/162694
+
+            using (var client = new HttpClient() { BaseAddress = baseAddress }) {
                 client.DefaultRequestHeaders.UserAgent.Add(userAgent);
                 var response = await client.GetAsync(releasesApiBuilder.ToString());
                 response.EnsureSuccessStatusCode();

--- a/src/Squirrel/UpdateManager.Factory.cs
+++ b/src/Squirrel/UpdateManager.Factory.cs
@@ -58,7 +58,7 @@ namespace Squirrel
 
                 var releases = SimpleJson.DeserializeObject<List<Release>>(await response.Content.ReadAsStringAsync());
                 var latestRelease = releases
-                    .Where(x => prerelease ? x.Prerelease : !x.Prerelease)
+                    .Where(x => prerelease || !x.Prerelease)
                     .OrderByDescending(x => x.PublishedAt)
                     .First();
 


### PR DESCRIPTION
* Squirrel now has ability to fetch releases from an Enterprise version of GitHub (b7eebcd80e192b6be26c2e3a7dc0e9ab68ea7887)
* Fixed the issue that when you said 'yes, I want prerelease versions', it would exclude normal release versions with a higher version number (7304c747fb4d0f6af763046fb87959302a69fe6c). 
* Using the `.Length()` method on a `List<T>` instead of `.Count()` extension method. Former is faster. (ae63e7ae565c996e31099c87176f0728c3d83698)