### PR TITLE
Remove AppCompat shims that applied to our applications

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using Squirrel.Shell;
 using ICSharpCode.SharpZipLib.Zip;
 using ICSharpCode.SharpZipLib.Core;
+using Microsoft.Win32;
 
 namespace Squirrel
 {
@@ -522,6 +523,24 @@ namespace Squirrel
                     }
 
                     break;
+                }
+            }
+
+            void unshimOurselves()
+            {
+                var regKey = default(RegistryKey);
+
+                try {
+                    regKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags");
+
+                    var toDelete = regKey.GetValueNames()
+                        .Where(x => x.StartsWith(rootAppDirectory, StringComparison.OrdinalIgnoreCase));
+
+                    toDelete.ForEach(x => regKey.DeleteValue(x));
+                } catch (Exception e) {
+                    this.Log().WarnException("Couldn't rewrite shim RegKey, most likely no apps are shimmed", e);
+                } finally {
+                    if (regKey != null) regKey.Dispose();
                 }
             }
 

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -73,6 +73,9 @@ namespace Squirrel
                 this.ErrorIfThrows(() => trayFixer.RemoveDeadEntries(allExes, rootAppDirectory, updateInfo.FutureReleaseEntry.Version.ToString()));
                 progress(80);
 
+                unshimOurselves();
+                progress(85);
+
                 try {
                     var currentVersion = updateInfo.CurrentlyInstalledVersion != null ?
                         updateInfo.CurrentlyInstalledVersion.Version : null;

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -529,7 +529,7 @@ namespace Squirrel
                 }
             }
 
-            void unshimOurselves()
+            internal void unshimOurselves()
             {
                 var regKey = default(RegistryKey);
 
@@ -539,7 +539,8 @@ namespace Squirrel
                     var toDelete = regKey.GetValueNames()
                         .Where(x => x.StartsWith(rootAppDirectory, StringComparison.OrdinalIgnoreCase));
 
-                    toDelete.ForEach(x => regKey.DeleteValue(x));
+                    toDelete.ForEach(x =>
+                        this.Log().LogIfThrows(LogLevel.Warn, "Failed to delete key: " + x, () => regKey.DeleteValue(x)));
                 } catch (Exception e) {
                     this.Log().WarnException("Couldn't rewrite shim RegKey, most likely no apps are shimmed", e);
                 } finally {

--- a/src/Update/Update.csproj
+++ b/src/Update/Update.csproj
@@ -34,6 +34,9 @@
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="DeltaCompressionDotNet">
       <HintPath>..\..\packages\DeltaCompressionDotNet.1.0.0\lib\net45\DeltaCompressionDotNet.dll</HintPath>
@@ -83,6 +86,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="app.manifest" />
     <None Include="packages.config" />
     <None Include="Update.com">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Update/app.manifest
+++ b/src/Update/app.manifest
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
+
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+
+</assembly>

--- a/test/ApplyReleasesTests.cs
+++ b/test/ApplyReleasesTests.cs
@@ -470,6 +470,17 @@ namespace Squirrel.Tests
                 Thread.Sleep(1000);
             }
         }
+        
+        [Fact]
+        public void UnshimOurselvesSmokeTest()
+        {
+            // NB: This smoke test is really more of a manual test - try it
+            // by shimming Slack, then verifying the shim goes away
+            var appDir = Environment.ExpandEnvironmentVariables(@"%LocalAppData%\Slack");
+            var fixture = new UpdateManager.ApplyReleasesImpl(appDir);
+
+            fixture.unshimOurselves();
+        }
 
         [Fact]
         public async Task GetShortcutsSmokeTest()


### PR DESCRIPTION
If for some reason, we get AppCompat shimmed, we want to unshim ourselves. We'll also include an App Manifest to prevent ourselves from being automatically shimmed by PCA