### PR TITLE
fixPinnedExecutables: check that taskbarPath exists

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -465,6 +465,11 @@ namespace Squirrel
                     Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                     "Microsoft\\Internet Explorer\\Quick Launch\\User Pinned\\TaskBar");
 
+                if (!Directory.Exists(taskbarPath)) {
+                    this.Log().Info("fixPinnedExecutables: PinnedExecutables directory doesn't exitsts, skiping...");
+                    return;
+                }
+
                 Func<FileInfo, ShellLink> resolveLink = file => {
                     try {
                         return new ShellLink(file.FullName);


### PR DESCRIPTION
I have a problem during app upgrade on one of the computers.
**"%ApplicationData% \ Microsoft \ Internet Explorer \ Quick Launch \ User Pinned \ TaskBar"** folder is missing.
As a result, a new version of the application was unpacked, but the method ApplyReleases fallen with exception.

I add check to fix this error.