### PR TITLE
Deal with missing HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\TrayNotify

### DIFF
--- a/src/Squirrel/TrayHelper.cs
+++ b/src/Squirrel/TrayHelper.cs
@@ -78,7 +78,7 @@ namespace Squirrel
                 return;
             }
 
-            if (iconStreamData.Length < 20) return;
+            if (iconStreamData == null || iconStreamData.Length < 20) return;
             var toKeep = new List<byte[]>();
             var header = default(IconStreamsHeader);
 


### PR DESCRIPTION
In case you are wondering how iconStreamData can possibly be null :

From https://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k(Microsoft.Win32.Registry.GetValue);k(TargetFrameworkMoniker-.NETFramework,Version%3Dv4.5.2);k(DevLang-csharp)&rd=true :

Return Value
Type: System.Object
null if the subkey specified by keyName does not exist; otherwise, the value associated with valueName, or defaultValue if valueName is not found.

This happens when installing for a user who has never logged in, using powershell's Invoke-Command  -Credential cmdlet.