### PR TITLE
Allow access_token from repoUrl

### DIFF
--- a/src/Squirrel/UpdateManager.Factory.cs
+++ b/src/Squirrel/UpdateManager.Factory.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web.HttpUtility;
 using Squirrel.Json;
 
 namespace Squirrel
@@ -46,8 +47,15 @@ namespace Squirrel
                 .Append(repoUri.AbsolutePath)
                 .Append("/releases");
 
-            if (!string.IsNullOrWhiteSpace(accessToken))
+            if (!string.IsNullOrWhiteSpace(accessToken)) {
                 releasesApiBuilder.Append("?access_token=").Append(accessToken);
+            } else {
+                accessToken = ParseQueryString(repoUri.Query).Get("access_token");
+
+                if (!string.IsNullOrWhiteSpace(accessToken)) {
+                    releasesApiBuilder.Append("?access_token=").Append(accessToken);
+                }
+            }
             
             Uri baseAddress;
 


### PR DESCRIPTION
Adds the ability to specify access token in repo url. This is useful in case you want to do something like:

```
Update.exe --download https://github.com/atom/atom?access_token=abc123
```