### PR TITLE
Add Mono's signcode for non-Windows builds

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -572,7 +572,7 @@ namespace Squirrel.Update
 
         static async Task signPEFile(string exePath, string signingOpts)
         {
-#if !MONO
+#if MONO
             // Use Mono's signcode tool
             var exe = "signcode";
 #endif;

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -575,9 +575,7 @@ namespace Squirrel.Update
 #if MONO
             // Use Mono's signcode tool
             var exe = "signcode";
-#endif;
-
-#if !MONO
+#else
             // Try to find SignTool.exe
             var exe = @".\signtool.exe";
             if (!File.Exists(exe)) {
@@ -588,7 +586,7 @@ namespace Squirrel.Update
                 // Run down PATH and hope for the best
                 if (!File.Exists(exe)) exe = "signtool.exe";
             }
-#endif;
+#endif
 
             Tuple<int, string> processResult = await Utility.InvokeProcessAsync(exe,
                 String.Format("sign {0} \"{1}\"", signingOpts, exePath), CancellationToken.None);

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -572,6 +572,12 @@ namespace Squirrel.Update
 
         static async Task signPEFile(string exePath, string signingOpts)
         {
+#if !MONO
+            // Use Mono's signcode tool
+            var exe = "signcode";
+#endif;
+
+#if !MONO
             // Try to find SignTool.exe
             var exe = @".\signtool.exe";
             if (!File.Exists(exe)) {
@@ -582,6 +588,7 @@ namespace Squirrel.Update
                 // Run down PATH and hope for the best
                 if (!File.Exists(exe)) exe = "signtool.exe";
             }
+#endif;
 
             Tuple<int, string> processResult = await Utility.InvokeProcessAsync(exe,
                 String.Format("sign {0} \"{1}\"", signingOpts, exePath), CancellationToken.None);


### PR DESCRIPTION
Since `signtool.exe` is broken with Mono, use Mono's built-in `signcode` tool.

This update `signcode` is available on the `$PATH` and that the developers signing the the release needs to put different options in `--signWithParams` to accommodate for the change.

Sample signing:

```
Update-Mono.exe --releasify ./app.1.0.0.nupkg --signWithParams -spc authenticode.spc -v authenticode.pvk -a sha1 -$ commercial -n My\ Application -i http://www.example.com/ -t http://timestamp.verisign.com/scripts/timstamp.dll -tr 10
```

More details can also be found at MDN: https://developer.mozilla.org/en-US/docs/Signing_an_executable_with_Authenticode

Fixes: #496 
