### PR TITLE
Don't copy the Mono variant of Update.exe into embedded zip

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -534,7 +534,7 @@ namespace Squirrel.Update
             this.Log().Info("Building embedded zip file for Setup.exe");
             using (Utility.WithTempDirectory(out tempPath, null)) {
                 this.ErrorIfThrows(() => {
-                    File.Copy(Assembly.GetEntryAssembly().Location, Path.Combine(tempPath, "Update.exe"));
+                    File.Copy(Assembly.GetEntryAssembly().Location.Replace("-Mono.exe", ".exe"), Path.Combine(tempPath, "Update.exe"));
                     File.Copy(fullPackage, Path.Combine(tempPath, Path.GetFileName(fullPackage)));
                 }, "Failed to write package files to temp dir: " + tempPath);
 


### PR DESCRIPTION
cf. https://github.com/atom/grunt-electron-installer/pull/80#issuecomment-156272858

Note that the generated Setup.exe still has trouble for me ([here's the log](https://gist.github.com/fasterthanlime/86407596c8f813ca910c)), am a bit lost on what to do next