### PR TITLE
Proposed MSI build fix

### DIFF
--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -177,7 +177,7 @@ namespace Squirrel
             }
         }
 
-        public static Task<Tuple<int, string>> InvokeProcessAsync(string fileName, string arguments, CancellationToken ct)
+        public static Task<Tuple<int, string>> InvokeProcessAsync(string fileName, string arguments, CancellationToken ct, string workingDirectory = null)
         {
             var psi = new ProcessStartInfo(fileName, arguments);
             if (Environment.OSVersion.Platform != PlatformID.Win32NT && fileName.EndsWith (".exe", StringComparison.OrdinalIgnoreCase)) {
@@ -190,6 +190,7 @@ namespace Squirrel
             psi.CreateNoWindow = true;
             psi.RedirectStandardOutput = true;
             psi.RedirectStandardError = true;
+            psi.WorkingDirectory = workingDirectory;
 
             return InvokeProcessAsync(psi, ct);
         }

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -663,7 +663,7 @@ namespace Squirrel.Update
 
             var candleParams = String.Format("-nologo -ext WixNetFxExtension -out \"{0}\" \"{1}\"", wxsTarget.Replace(".wxs", ".wixobj"), wxsTarget);
             var processResult = await Utility.InvokeProcessAsync(
-                Path.Combine(pathToWix, "candle.exe"), candleParams, CancellationToken.None);
+                Path.Combine(pathToWix, "candle.exe"), candleParams, CancellationToken.None, setupExeDir);
 
             if (processResult.Item1 != 0) {
                 var msg = String.Format(
@@ -675,7 +675,7 @@ namespace Squirrel.Update
 
             var lightParams = String.Format("-ext WixNetFxExtension -sval -out \"{0}\" \"{1}\"", wxsTarget.Replace(".wxs", ".msi"), wxsTarget.Replace(".wxs", ".wixobj"));
             processResult = await Utility.InvokeProcessAsync(
-                Path.Combine(pathToWix, "light.exe"), lightParams, CancellationToken.None);
+                Path.Combine(pathToWix, "light.exe"), lightParams, CancellationToken.None, setupExeDir);
 
             if (processResult.Item1 != 0) {
                 var msg = String.Format(


### PR DESCRIPTION
Proposed MSI build fix to make createMsiPackage(...) explicitly supply path to releases directory to both candle and light. Target setup.exe is located in releases directory. This fix prevents MSI builder from picking up incorrect (bootstrapper) setup.exe located in working directory (tools).