### PR TITLE
InvokeProcessAsync workingDirectory param default to empty string

### DIFF
--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -177,7 +177,7 @@ namespace Squirrel
             }
         }
 
-        public static Task<Tuple<int, string>> InvokeProcessAsync(string fileName, string arguments, CancellationToken ct, string workingDirectory = null)
+        public static Task<Tuple<int, string>> InvokeProcessAsync(string fileName, string arguments, CancellationToken ct, string workingDirectory = "")
         {
             var psi = new ProcessStartInfo(fileName, arguments);
             if (Environment.OSVersion.Platform != PlatformID.Win32NT && fileName.EndsWith (".exe", StringComparison.OrdinalIgnoreCase)) {


### PR DESCRIPTION
According to Microsoft https://msdn.microsoft.com/en-us/library/system.diagnostics.processstartinfo.workingdirectory%28v=vs.110%29.aspx ProcessStartInfo.WorkingDirectory Property default value is empty string. It does not affect anything but in such sensitive area better be safe than sorry.