### PR TITLE
Make splash/loading window draggable

### DIFF
--- a/src/Update/AnimatedGifWindow.cs
+++ b/src/Update/AnimatedGifWindow.cs
@@ -1,19 +1,15 @@
 ﻿#if !MONO
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Effects;
 using System.Windows.Media.Imaging;
 using System.Windows.Shell;
-using System.Windows.Threading;
 using WpfAnimatedGif;
 
 namespace Squirrel.Update
@@ -88,6 +84,12 @@ namespace Squirrel.Update
 
             thread.SetApartmentState(ApartmentState.STA);
             thread.Start();
+        }
+
+        protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+        {
+            base.OnMouseLeftButtonDown(e);
+            this.DragMove();
         }
     }
 }


### PR DESCRIPTION
It's a little annoying that the splash/loading screen might be obscuring something (mine was) even for just 10 seconds... but making it draggable is easy.