### PR TITLE
Fix Content Types created by Mono

### DIFF
--- a/src/Squirrel/ContentType.cs
+++ b/src/Squirrel/ContentType.cs
@@ -6,6 +6,23 @@ namespace Squirrel
 {
     internal static class ContentType
     {
+        public static void Clean(XmlDocument doc)
+        {
+            var typesElement = doc.FirstChild.NextSibling;
+            if (typesElement.Name.ToLowerInvariant() != "types") {
+                throw new Exception("Invalid ContentTypes file, expected root node should be 'Types'");
+            }
+
+            var children = typesElement.ChildNodes.OfType<XmlElement>();
+            for (var child in children)
+            {
+                if (child.GetAttribute("Extension") == "")
+                {
+                    typesElement.RemoveChild(child);
+                }
+            }
+        }
+
         public static void Merge(XmlDocument doc)
         {
             var elements = new [] {

--- a/src/Squirrel/ReleasePackage.cs
+++ b/src/Squirrel/ReleasePackage.cs
@@ -349,6 +349,7 @@ namespace Squirrel
             doc.Load(path);
 
             ContentType.Merge(doc);
+            ContentType.Clean(doc);
 
             using (var sw = new StreamWriter(path, false, Encoding.UTF8)) {
                 doc.Save(sw);


### PR DESCRIPTION
Attempts to remove default content types in `[Content_Types].xml` with empty Extensions.

This happens when adding a file via your NuSpec file with no extension, such as `LICENSE`.

Fixes #520 

/cc @fasterthanlime 