### PR TITLE
Docs Packaging Tools Reformat

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -37,7 +37,7 @@ The **[Getting Started Guide](getting-started/0-overview.md)** provides a step-b
 * **Packaging** - documentation related to packaging app files and preparing them for release.
   * [Naming Conventions](using/naming.md) - overview of sources used in naming (e.g., shortcut name).
   * [NuGet Package Metadata](using/nuget-package-metadata.md) - overview of the NuGet metadata and its uses by Squirrel.
-  * [Using OctoPack](using/octopack.md) - steps to use OctoPack to build the source NuGet package to provide to `squirrel --releasify`.
+  * [Packaging Tools](using/packaging-tools.md) - tools available to assist in the process of packaging your application (e.g., NuGet, OctoPack, Auto.Squirrel)
   * [Squirrel Command Line](using/squirrel-command-line.md) - command line options for `Squirrel --releasify`
   * [Delta Packages](using/delta-packages.md) - an overview of how `Squirrel.exe` creates delta packages.
   * [Application Signing](using/application-signing.md) - adding code signing to `Setup.exe` and your application.

--- a/docs/using/octopack.md
+++ b/docs/using/octopack.md
@@ -26,7 +26,7 @@ If you're building using Visual Studio, you will also need to edit your .csproj 
 If you're using a build server, see OctoPack's guides on how to trigger it to be run.
 
 ---
-| Return: [Table of Contents](../readme.md) |
+| Return: [Packaging Tools](packaging-tools.md) |
 |----|
 
 

--- a/docs/using/packaging-tools.md
+++ b/docs/using/packaging-tools.md
@@ -1,0 +1,23 @@
+| [docs](..)  / [using](.) / packaging-tools.md
+|:---|
+
+
+# Packaging Tools
+
+The following tools can simplify and/or automate the packaging process.
+
+* [NuGet Docs](http://docs.nuget.org/) - documentation for NuGet packaging manager.
+* [NuGet Package Explorer](https://npe.codeplex.com/) - GUI tool for building NuGet packages.
+* [OctoPack](octopack.md) - steps to use OctoPack to build the source NuGet package to provide to `squirrel --releasify`.
+* [Auto.Squirrel Package Manager](https://github.com/tenacious/Auto.Squirrel) - tool to fully automatize the application deploy, from build to upload the updated files.
+ 
+
+## See Also
+
+* [Step 2. Packaging](../getting-started/2-packaging.md) - step from getting started guide on using NuGet Package Explorer. 
+
+
+---
+| Return: [Table of Contents](../readme.md) |
+|----|
+


### PR DESCRIPTION
Move OctoPack link under Packaging Tools page and add links to NuGet Docs and Auto.Squirrel.