### PR TITLE
Remove machine install as a Thing

### DIFF
--- a/src/Setup/MachineInstaller.cpp
+++ b/src/Setup/MachineInstaller.cpp
@@ -4,51 +4,6 @@
 #include "resource.h"
 #include <sddl.h>
 
-bool findPackageFromEmbeddedZip(wchar_t* buf, DWORD cbSize) 
-{
-	bool ret = false;
-
-	CResource zipResource;
-	if (!zipResource.Load(L"DATA", IDR_UPDATE_ZIP)) {
-		return false;
-	}
-
-	DWORD dwSize = zipResource.GetSize();
-	if (dwSize < 0x100) {
-		return false;
-	}
-
-	BYTE* pData = (BYTE*)zipResource.Lock();
-	HZIP zipFile = OpenZip(pData, dwSize, NULL);
-
-	ZRESULT zr;
-	int index = 0;
-	do {
-		ZIPENTRY zentry;
-
-		zr = GetZipItem(zipFile, index, &zentry);
-		if (zr != ZR_OK && zr != ZR_MORE) {
-			break;
-		}
-
-		if (wcsstr(zentry.name, L"nupkg")) {
-			ZeroMemory(buf, cbSize);
-
-			int idx = wcscspn(zentry.name, L"-");
-			memcpy(buf, zentry.name, sizeof(wchar_t) * idx);
-			ret = true;
-			break;
-		}
-
-		index++;
-	} while (zr == ZR_MORE || zr == ZR_OK);
-
-	CloseZip(zipFile);
-	zipResource.Release();
-
-	return ret;
-}
-
 bool directoryExists(wchar_t* path) {
 	DWORD dwResult = GetFileAttributes(path);
 
@@ -64,81 +19,12 @@ bool directoryExists(wchar_t* path) {
 	return true;
 }
 
-int MachineInstaller::PerformMachineInstallSetup()
-{
-	wchar_t packageName[512];
-
-	if (!findPackageFromEmbeddedZip(packageName, sizeof(packageName))) {
-		MessageBox(NULL, L"Corrupt installer", L"Cannot find package name for installer, is it created correctly?", MB_OK);
-		return ERROR_INVALID_PARAMETER;
-	}
-
-	wchar_t machineInstallFolder[MAX_PATH];
-	SHGetFolderPath(NULL, CSIDL_COMMON_APPDATA, NULL, SHGFP_TYPE_CURRENT, machineInstallFolder);
-	wcscat(machineInstallFolder, L"\\SquirrelMachineInstalls");
-
-	// NB: This is the DACL for Program Files
-	wchar_t sddl[512] = L"D:PAI(A;;FA;;;S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464)(A;CIIO;GA;;;S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464)(A;;0x1301bf;;;SY)(A;OICIIO;GA;;;SY)(A;;0x1301bf;;;BA)(A;OICIIO;GA;;;BA)(A;;0x1200a9;;;BU)(A;OICIIO;GXGR;;;BU)(A;OICIIO;GA;;;CO)";
-
-	if (IsWindows8OrGreater()) {
-		// Add ALL APPLICATION PACKAGES account (Only available on Windows 8 and greater)
-		wcscat(sddl, L"(A;;0x1200a9;;;AC)(A;OICIIO;GXGR;;;AC)");
-	}
-
-	PSECURITY_DESCRIPTOR descriptor;
-	ConvertStringSecurityDescriptorToSecurityDescriptor(
-		sddl,
-		SDDL_REVISION_1,
-		&descriptor, NULL);
-
-	SECURITY_ATTRIBUTES attrs;
-	attrs.nLength = sizeof(SECURITY_ATTRIBUTES);
-	attrs.bInheritHandle = false;
-	attrs.lpSecurityDescriptor = descriptor;
-
-	if (!CreateDirectory(machineInstallFolder, &attrs) && GetLastError() != ERROR_ALREADY_EXISTS) {
-		LocalFree(descriptor);
-		return GetLastError();
-	}
-
-	LocalFree(descriptor);
-
-	wcscat(machineInstallFolder, L"\\");
-	wcscat(machineInstallFolder, packageName);
-	wcscat(machineInstallFolder, L".exe");
-
-	wchar_t ourFile[MAX_PATH];
-	HMODULE hMod = GetModuleHandle(NULL);
-	GetModuleFileName(hMod, ourFile, _countof(ourFile));
-
-	if (!CopyFile(ourFile, machineInstallFolder, false)) {
-		return GetLastError();
-	}
-
-	HKEY runKey;
-	DWORD dontcare;
-	if (RegCreateKeyEx(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", 0, NULL, 0, KEY_ALL_ACCESS, NULL, &runKey, &dontcare) != ERROR_SUCCESS) {
-		return GetLastError();
-	}
-
-	wcscat_s(machineInstallFolder, L" --checkInstall");
-
-	if (RegSetValueEx(runKey, packageName, 0, REG_SZ, (BYTE*)machineInstallFolder, (wcsnlen(machineInstallFolder, sizeof(machineInstallFolder)) + 1) * sizeof(wchar_t)) != ERROR_SUCCESS) {
-		return GetLastError();
-	}
-
-	RegCloseKey(runKey);
-	return 0;
-}
-
-
 bool MachineInstaller::ShouldSilentInstall()
 {
 	// Figure out the package name from our own EXE name 
 	wchar_t ourFile[MAX_PATH];
 	HMODULE hMod = GetModuleHandle(NULL);
 	GetModuleFileName(hMod, ourFile, _countof(ourFile));
-
 
 	CString fullPath = CString(ourFile);
 	CString pkgName = CString(ourFile + fullPath.ReverseFind(L'\\'));

--- a/src/Setup/MachineInstaller.h
+++ b/src/Setup/MachineInstaller.h
@@ -2,7 +2,6 @@
 class MachineInstaller
 {
 public:
-	static int PerformMachineInstallSetup();
 	static bool ShouldSilentInstall();
 };
 


### PR DESCRIPTION
This PR removes machine installation now that we have MSI packages, and more importantly hard-blocks folx from running our installer as an elevated administrator.

This PR also improves the MSI `checkInstall` code to completely refuse to do anything if the package directory exists in any way. This prevents installers from getting into this "rolling install" scenario where we somehow decide to pave over our own installation, then continually corrupt it instead.

## TODO:

- [x] Test with normal UAC settings
- [x] Test with UAC disabled