### PR TITLE
MSI consistent hashes for UpgradeCode

### DIFF
--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -584,6 +584,82 @@ namespace Squirrel
             MOVEFILE_CREATE_HARDLINK = 0x00000010,
             MOVEFILE_FAIL_IF_NOT_TRACKABLE = 0x00000020
         }
+
+        public static Guid CreateGuidFromHash(string text)
+        {
+            return CreateGuidFromHash(text, Utility.IsoOidNamespace);
+        }
+
+
+        public static Guid CreateGuidFromHash(string text, Guid namespaceId)
+        {
+            // convert the name to a sequence of octets (as defined by the standard 
+            // or conventions of its namespace) (step 3)
+            byte[] nameBytes = Encoding.UTF8.GetBytes(text);
+
+            // convert the namespace UUID to network order (step 3)
+            byte[] namespaceBytes = namespaceId.ToByteArray();
+            SwapByteOrder(namespaceBytes);
+
+            // comput the hash of the name space ID concatenated with the 
+            // name (step 4)
+            byte[] hash;
+            using (var algorithm = SHA1.Create()) {
+                algorithm.TransformBlock(namespaceBytes, 0, namespaceBytes.Length, null, 0);
+                algorithm.TransformFinalBlock(nameBytes, 0, nameBytes.Length);
+                hash = algorithm.Hash;
+            }
+
+            // most bytes from the hash are copied straight to the bytes of 
+            // the new GUID (steps 5-7, 9, 11-12)
+            var newGuid = new byte[16];
+            Array.Copy(hash, 0, newGuid, 0, 16);
+
+            // set the four most significant bits (bits 12 through 15) of 
+            // the time_hi_and_version field to the appropriate 4-bit 
+            // version number from Section 4.1.3 (step 8)
+            newGuid[6] = (byte)((newGuid[6] & 0x0F) | (5 << 4));
+
+            // set the two most significant bits (bits 6 and 7) of the 
+            // clock_seq_hi_and_reserved to zero and one, respectively 
+            // (step 10)
+            newGuid[8] = (byte)((newGuid[8] & 0x3F) | 0x80);
+
+            // convert the resulting UUID to local byte order (step 13)
+            SwapByteOrder(newGuid);
+            return new Guid(newGuid);
+        }
+
+        /// <summary>
+        /// The namespace for fully-qualified domain names (from RFC 4122, Appendix C).
+        /// </summary>
+        public static readonly Guid DnsNamespace = new Guid("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+
+        /// <summary>
+        /// The namespace for URLs (from RFC 4122, Appendix C).
+        /// </summary>
+        public static readonly Guid UrlNamespace = new Guid("6ba7b811-9dad-11d1-80b4-00c04fd430c8");
+
+        /// <summary>
+        /// The namespace for ISO OIDs (from RFC 4122, Appendix C).
+        /// </summary>
+        public static readonly Guid IsoOidNamespace = new Guid("6ba7b812-9dad-11d1-80b4-00c04fd430c8");
+
+        // Converts a GUID (expressed as a byte array) to/from network order (MSB-first).
+        static void SwapByteOrder(byte[] guid)
+        {
+            SwapBytes(guid, 0, 3);
+            SwapBytes(guid, 1, 2);
+            SwapBytes(guid, 4, 5);
+            SwapBytes(guid, 6, 7);
+        }
+
+        static void SwapBytes(byte[] guid, int left, int right)
+        {
+            byte temp = guid[left];
+            guid[left] = guid[right];
+            guid[right] = temp;
+        }
     }
 
     static unsafe class UnsafeUtility

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -207,7 +207,7 @@ namespace Squirrel.Update
                     this.Log().Warn("Install path {0} already exists, burning it to the ground", mgr.RootAppDirectory);
 
                     mgr.KillAllExecutablesBelongingToPackage();
-                    await Task.Delay(250);
+                    await Task.Delay(500);
 
                     await this.ErrorIfThrows(() => Utility.DeleteDirectory(mgr.RootAppDirectory),
                         "Failed to remove existing directory on full install, is the app still running???");

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -655,13 +655,21 @@ namespace Squirrel.Update
             var company = String.Join(",", package.Authors);
 
             var templateText = File.ReadAllText(Path.Combine(pathToWix, "template.wxs"));
-            var templateResult = CopStache.Render(templateText, new Dictionary<string, string> {
+            var templateData = new Dictionary<string, string> {
                 { "Id", package.Id },
                 { "Title", package.Title },
                 { "Author", company },
                 { "Version", Regex.Replace(package.Version.ToString(), @"-.*$", "") },
                 { "Summary", package.Summary ?? package.Description ?? package.Id },
-            });
+            };
+
+            // NB: We need some GUIDs that are based on the package ID, but unique (i.e.
+            // "Unique but consistent").
+            for (int i=1; i <= 10; i++) {
+                templateData[String.Format("IdAsGuid{0}", i)] = Utility.CreateGuidFromHash(String.Format("{0}:{1}", package.Id, i)).ToString();
+            }
+
+            var templateResult = CopStache.Render(templateText, templateData);
 
             var wxsTarget = Path.Combine(setupExeDir, "Setup.wxs");
             File.WriteAllText(wxsTarget, templateResult, Encoding.UTF8);

--- a/vendor/wix/template.wxs
+++ b/vendor/wix/template.wxs
@@ -1,5 +1,5 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension">
-  <Product Id="*" Name="{{Title}} Machine-Wide Installer" Language="1033" Version="{{Version}}" UpgradeCode="{{RandomGuid}}" Manufacturer="{{Author}}">
+  <Product Id="*" Name="{{Title}} Machine-Wide Installer" Language="1033" Version="{{Version}}" UpgradeCode="{{IdAsGuid1}}" Manufacturer="{{Author}}">
 
     <Package Description="#Description" Comments="Comments" InstallerVersion="200" Compressed="yes"/>
 		<Media Id="1" Cabinet="contents.cab" EmbedCab="yes" CompressionLevel="high"/>
@@ -17,13 +17,13 @@
     </Directory>
 
     <DirectoryRef Id="APPLICATIONROOTDIRECTORY">
-      <Component Id="{{Id}}.exe" Guid="{{RandomGuid}}">
+      <Component Id="{{Id}}.exe" Guid="{{IdAsGuid2}}">
         <File Id="{{Id}}.exe" Name="{{Id}}.exe" Source="./Setup.exe" KeyPath="yes" />
       </Component>
     </DirectoryRef>
 
     <DirectoryRef Id="TARGETDIR">
-      <Component Id="RegistryEntries" Guid="{{RandomGuid}}">
+      <Component Id="RegistryEntries" Guid="{{IdAsGuid3}}">
         <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Run">
           <RegistryValue Type="expandable" Name="{{Id}}MachineInstaller" Value="%ProgramFiles%\{{Title}} Installer\{{Id}}.exe --checkInstall" />
         </RegistryKey>


### PR DESCRIPTION
Right now, we currently generate random GUIDs for our MSI component IDs. This means, that if you use GPOs to push down an MSI file for v1.0, then push down another MSI file for v2.0, we get the same app installed twice / weird stuff happens / etc etc. Instead, we'll base our GUIDs on a derivative of the package ID