### PR TITLE
Redundant kill all processes

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -122,17 +122,6 @@ namespace Squirrel
                         } else {
                             allApps.ForEach(x => RemoveShortcutsForExecutable(x.Name, ShortcutLocation.StartMenu | ShortcutLocation.Desktop));
                         }
-
-                        // NB: Some people attempt to uninstall apps while 
-                        // they're still running. I cannot even.
-                        var toKill = allApps
-                            .SelectMany(x => Process.GetProcessesByName(x.Name.Replace(".exe", "")))
-                            .ToList();
-
-                        if (toKill.Count > 0) {
-                            toKill.ForEach(x => x.Kill());
-                            Thread.Sleep(750);
-                        }
                     } catch (Exception ex) {
                         this.Log().WarnException("Failed to run pre-uninstall hooks, uninstalling anyways", ex);
                     }


### PR DESCRIPTION
Fix to resolve #662, seems the problem code is actually redundant due to a call to `KillAllExecutablesBelongingToPackage` in `UpdateManager.FullUninstall` prior to `ApplyReleasesImpl.FullUninstall` being called.

Now GitHub for Windows doesn't crash! :tada: