### PR TITLE
Staged rollouts

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -50,6 +50,7 @@ The **[Getting Started Guide](getting-started/0-overview.md)** provides a step-b
   * [Update Manager](using/update-manager.md) - reference guide for the `UpdateManager`.  
   * [GitHub](using/github.md) - overview of using GitHub for installing, distributing, and updating.  
   * [Debugging Updates](using/debugging-updates.md) - tips for debugging Squirrel.Windows updates.
+  * [Staged Rollouts](using/staged-rollouts.md) - how to use staged rollouts to ramp up install distribution over time
 
 
 ## Contributing

--- a/docs/using/staged-rollouts.md
+++ b/docs/using/staged-rollouts.md
@@ -1,0 +1,50 @@
+| [docs](..)  / [using](.) / staged-rollouts.md
+|:---|
+
+# Staged Rollouts
+
+Staged rollouts allow you to distribute the latest version of your app to a subset of users that you can increase over time, similar to rollouts on platforms like Google Play. This feature requires Squirrel.Windows 1.4.0 or above.
+
+### How to use
+
+Staged rollouts are controlled by manually editing your `RELEASES` file. Here's an example:
+
+~~~
+e3f67244e4166a65310c816221a12685c83f8e6f myapp-1.0.0-full.nupkg 600725
+~~~
+
+Now let's ship a new version to 10% of our userbase.
+
+```
+e3f67244e4166a65310c816221a12685c83f8e6f myapp-1.0.0-full.nupkg 600725
+0d777ea94c612e8bf1ea7379164caefba6e24463 myapp-1.0.1-delta.nupkg 6030# 10%
+85f4d657f8424dd437d1b33cc4511ea7ad86b1a7 myapp-1.0.1-full.nupkg 600752# 10%
+```
+
+Note that the syntax is `# nn%` - due to a bug in earlier versions of Squirrel.Windows, for now, you *must* put the `#` immediately following the file size, no spaces. Once all of your users have Squirrel 1.4.0 or higher, you can add a space after the `#` (similar to a comment).
+
+Assuming that this rollout is going well, at some point you can upload a new version of the releases file:
+
+```
+e3f67244e4166a65310c816221a12685c83f8e6f myapp-1.0.0-full.nupkg 600725
+0d777ea94c612e8bf1ea7379164caefba6e24463 myapp-1.0.1-delta.nupkg 6030# 50%
+85f4d657f8424dd437d1b33cc4511ea7ad86b1a7 myapp-1.0.1-full.nupkg 600752# 50%
+```
+
+When you're confident that this release has gone successfully, you can remove the comment so that 100% of users get the file:
+
+```
+e3f67244e4166a65310c816221a12685c83f8e6f myapp-1.0.0-full.nupkg 600725
+0d777ea94c612e8bf1ea7379164caefba6e24463 myapp-1.0.1-delta.nupkg 6030
+85f4d657f8424dd437d1b33cc4511ea7ad86b1a7 myapp-1.0.1-full.nupkg 600752
+```
+
+### Handling failed rollouts
+
+If you want to pull a staged release because it hasn't gone well, you should hand-edit the RELEASES file to completely remove the bad version:
+
+~~~
+e3f67244e4166a65310c816221a12685c83f8e6f myapp-1.0.0-full.nupkg 600725
+~~~
+
+Once you do this, you **must** increment the version number higher than your broken release (in this example, we would need to release MyApp 1.0.2). Because some of your users will be on the broken 1.0.1, releasing a _new_ 1.0.1 would result in them staying on a broken version.

--- a/docs/using/staged-rollouts.md
+++ b/docs/using/staged-rollouts.md
@@ -23,7 +23,7 @@ e3f67244e4166a65310c816221a12685c83f8e6f myapp-1.0.0-full.nupkg 600725
 
 Note that the syntax is `# nn%` - due to a bug in earlier versions of Squirrel.Windows, for now, you *must* put the `#` immediately following the file size, no spaces. Once all of your users have Squirrel 1.4.0 or higher, you can add a space after the `#` (similar to a comment).
 
-Assuming that this rollout is going well, at some point you can upload a new version of the releases file:
+Assuming that this rollout is going well, at some point you can upload a new version of the `RELEASES` file:
 
 ```
 e3f67244e4166a65310c816221a12685c83f8e6f myapp-1.0.0-full.nupkg 600725

--- a/src/Squirrel/ReleaseEntry.cs
+++ b/src/Squirrel/ReleaseEntry.cs
@@ -53,7 +53,7 @@ namespace Squirrel
         public string EntryAsString {
             get {
                 if (StagingPercentage != null) {
-                    return String.Format("{0} {1}{2} {3} # ${4}", SHA1, BaseUrl, Filename, Filesize, stagingPercentageAsString(StagingPercentage.Value));
+                    return String.Format("{0} {1}{2} {3} # {4}", SHA1, BaseUrl, Filename, Filesize, stagingPercentageAsString(StagingPercentage.Value));
                 } else {
                     return String.Format("{0} {1}{2} {3}", SHA1, BaseUrl, Filename, Filesize);
                 }

--- a/src/Squirrel/ReleaseEntry.cs
+++ b/src/Squirrel/ReleaseEntry.cs
@@ -22,6 +22,7 @@ namespace Squirrel
         string EntryAsString { get; }
         SemanticVersion Version { get; }
         string PackageName { get; }
+        float? StagingPercentage { get; }
 
         string GetReleaseNotes(string packageDirectory);
         Uri GetIconUrl(string packageDirectory);
@@ -36,15 +37,16 @@ namespace Squirrel
         [DataMember] public string Query { get; protected set; }
         [DataMember] public long Filesize { get; protected set; }
         [DataMember] public bool IsDelta { get; protected set; }
+        [DataMember] public float? StagingPercentage { get; protected set; }
 
-        protected ReleaseEntry(string sha1, string filename, long filesize, bool isDelta, string baseUrl = null, string query = null)
+        protected ReleaseEntry(string sha1, string filename, long filesize, bool isDelta, string baseUrl = null, string query = null, float? stagingPercentage = null)
         {
             Contract.Requires(sha1 != null && sha1.Length == 40);
             Contract.Requires(filename != null);
             Contract.Requires(filename.Contains(Path.DirectorySeparatorChar) == false);
             Contract.Requires(filesize > 0);
 
-            SHA1 = sha1; BaseUrl = baseUrl;  Filename = filename; Query = query; Filesize = filesize; IsDelta = isDelta;
+            SHA1 = sha1; BaseUrl = baseUrl;  Filename = filename; Query = query; Filesize = filesize; IsDelta = isDelta; StagingPercentage = stagingPercentage;
         }
 
         [IgnoreDataMember]

--- a/src/Squirrel/ReleaseEntry.cs
+++ b/src/Squirrel/ReleaseEntry.cs
@@ -51,7 +51,13 @@ namespace Squirrel
 
         [IgnoreDataMember]
         public string EntryAsString {
-            get { return String.Format("{0} {1}{2} {3}", SHA1, BaseUrl, Filename, Filesize); }
+            get {
+                if (StagingPercentage != null) {
+                    return String.Format("{0} {1}{2} {3} # ${4}", SHA1, BaseUrl, Filename, Filesize, stagingPercentageAsString(StagingPercentage.Value));
+                } else {
+                    return String.Format("{0} {1}{2} {3}", SHA1, BaseUrl, Filename, Filesize);
+                }
+            }
         }
 
         [IgnoreDataMember]
@@ -225,6 +231,11 @@ namespace Squirrel
             }
 
             return entries;
+        }
+
+        static string stagingPercentageAsString(float percentage)
+        {
+            return String.Format("{0:F0}%", percentage * 100.0));
         }
 
         static bool filenameIsDeltaFile(string filename)

--- a/src/Squirrel/ReleaseEntry.cs
+++ b/src/Squirrel/ReleaseEntry.cs
@@ -95,7 +95,7 @@ namespace Squirrel
 
             float? stagingPercentage = null;
             var m = stagingRegex.Match(entry);
-            if (m != null) {
+            if (m != null && m.Success) {
                 stagingPercentage = Single.Parse(m.Groups[0].Value);
             }
 

--- a/src/Squirrel/ReleaseEntry.cs
+++ b/src/Squirrel/ReleaseEntry.cs
@@ -87,7 +87,7 @@ namespace Squirrel
         }
 
         static readonly Regex entryRegex = new Regex(@"^([0-9a-fA-F]{40})\s+(\S+)\s+(\d+)[\r]*$");
-        static readonly Regex commentRegex = new Regex(@"#.*$");
+        static readonly Regex commentRegex = new Regex(@"\s*#.*$");
         static readonly Regex stagingRegex = new Regex(@"#\s+(\d{1,3})%$");
         public static ReleaseEntry ParseReleaseEntry(string entry)
         {
@@ -96,7 +96,7 @@ namespace Squirrel
             float? stagingPercentage = null;
             var m = stagingRegex.Match(entry);
             if (m != null && m.Success) {
-                stagingPercentage = Single.Parse(m.Groups[0].Value);
+                stagingPercentage = Single.Parse(m.Groups[1].Value) / 100.0f;
             }
 
             entry = commentRegex.Replace(entry, "");

--- a/src/Squirrel/ReleaseEntry.cs
+++ b/src/Squirrel/ReleaseEntry.cs
@@ -115,7 +115,7 @@ namespace Squirrel
 
             string filename = m.Groups[2].Value;
 
-            // Split the base URL and the filename if an URI is provided, 
+            // Split the base URL and the filename if an URI is provided,
             // throws if a path is provided
             string baseUrl = null;
             string query = null;
@@ -137,7 +137,7 @@ namespace Squirrel
                     query = uri.Query;
                 }
             }
-            
+
             if (filename.IndexOfAny(Path.GetInvalidFileNameChars()) > -1) {
                 throw new Exception("Filename can either be an absolute HTTP[s] URL, *or* a file name");
             }
@@ -150,6 +150,9 @@ namespace Squirrel
 
         public bool IsStagingMatch(Guid? userId)
         {
+            // A "Staging match" is when a user falls into the affirmative
+            // bucket - i.e. if the staging is at 10%, this user is the one out
+            // of ten case.
             if (!StagingPercentage.HasValue) return true;
             if (!userId.HasValue) return false;
 

--- a/src/Squirrel/UpdateManager.CheckForUpdates.cs
+++ b/src/Squirrel/UpdateManager.CheckForUpdates.cs
@@ -23,7 +23,7 @@ namespace Squirrel
             public async Task<UpdateInfo> CheckForUpdate(
                 string localReleaseFile,
                 string updateUrlOrPath,
-                bool ignoreDeltaUpdates = false, 
+                bool ignoreDeltaUpdates = false,
                 Action<int> progress = null,
                 IFileDownloader urlDownloader = null)
             {
@@ -45,11 +45,11 @@ namespace Squirrel
 
                 string releaseFile;
 
-                var latestLocalRelease = localReleases.Count() > 0 ? 
-                    localReleases.MaxBy(x => x.Version).First() : 
+                var latestLocalRelease = localReleases.Count() > 0 ?
+                    localReleases.MaxBy(x => x.Version).First() :
                     default(ReleaseEntry);
 
-                // Fetch the remote RELEASES file, whether it's a local dir or an 
+                // Fetch the remote RELEASES file, whether it's a local dir or an
                 // HTTP URL
                 if (Utility.IsHttpUrl(updateUrlOrPath)) {
                     if (updateUrlOrPath.EndsWith("/")) {
@@ -89,7 +89,7 @@ namespace Squirrel
 
                     if (!Directory.Exists(updateUrlOrPath)) {
                         var message = String.Format(
-                            "The directory {0} does not exist, something is probably broken with your application", 
+                            "The directory {0} does not exist, something is probably broken with your application",
                             updateUrlOrPath);
 
                         throw new Exception(message);
@@ -98,7 +98,7 @@ namespace Squirrel
                     var fi = new FileInfo(Path.Combine(updateUrlOrPath, "RELEASES"));
                     if (!fi.Exists) {
                         var message = String.Format(
-                            "The file {0} does not exist, something is probably broken with your application", 
+                            "The file {0} does not exist, something is probably broken with your application",
                             fi.FullName);
 
                         this.Log().Warn(message);
@@ -118,7 +118,7 @@ namespace Squirrel
                 }
 
                 var ret = default(UpdateInfo);
-                var remoteReleases = ReleaseEntry.ParseReleaseFileAndApplyStaging(releaseFile, stagingId); 
+                var remoteReleases = ReleaseEntry.ParseReleaseFileAndApplyStaging(releaseFile, stagingId);
                 progress(66);
 
                 if (!remoteReleases.Any()) {
@@ -126,7 +126,7 @@ namespace Squirrel
                 }
 
                 ret = determineUpdateInfo(localReleases, remoteReleases, ignoreDeltaUpdates);
-                
+
                 progress(100);
                 return ret;
             }
@@ -192,7 +192,7 @@ namespace Squirrel
                     this.Log().Info("Using existing staging user ID: {0}", ret.ToString());
                     return ret;
                 } catch (Exception ex) {
-                    this.Log().InfoException("Couldn't read staging user ID, creating a blank one", ex);
+                    this.Log().DebugException("Couldn't read staging user ID, creating a blank one", ex);
                 }
 
                 var prng = new Random();

--- a/src/Squirrel/UpdateManager.DownloadReleases.cs
+++ b/src/Squirrel/UpdateManager.DownloadReleases.cs
@@ -109,7 +109,6 @@ namespace Squirrel
                     }
                 }
             }
-
         }
     }
 }

--- a/src/Squirrel/UpdateManager.DownloadReleases.cs
+++ b/src/Squirrel/UpdateManager.DownloadReleases.cs
@@ -109,6 +109,35 @@ namespace Squirrel
                     }
                 }
             }
+
+            internal Guid? getOrCreateStagedUserId()
+            {
+                var stagedUserIdFile = Path.Combine(rootAppDirectory, "packages", ".betaId");
+                var ret = default(Guid);
+
+                try {
+                    if (!Guid.TryParse(File.ReadAllText(stagedUserIdFile, Encoding.UTF8), out ret)) {
+                        throw new Exception("File was read but contents were invalid");
+                    }
+
+                    return ret;
+                } catch (Exception ex) {
+                    this.Log().InfoException("Couldn't read staging user ID, creating a blank one", ex);
+                }
+
+                var prng = new Random();
+                var buf = new byte[4096];
+                prng.NextBytes(buf);
+
+                ret = Utility.CreateGuidFromHash(buf);
+                try {
+                    File.WriteAllText(stagedUserIdFile, ret.ToString(), Encoding.UTF8);
+                    return ret;
+                } catch (Exception ex) {
+                    this.Log().WarnException("Couldn't write out staging user ID, this user probably shouldn't get beta anything", ex);
+                    return null;
+                }
+            }
         }
     }
 }

--- a/src/Squirrel/UpdateManager.DownloadReleases.cs
+++ b/src/Squirrel/UpdateManager.DownloadReleases.cs
@@ -110,34 +110,6 @@ namespace Squirrel
                 }
             }
 
-            internal Guid? getOrCreateStagedUserId()
-            {
-                var stagedUserIdFile = Path.Combine(rootAppDirectory, "packages", ".betaId");
-                var ret = default(Guid);
-
-                try {
-                    if (!Guid.TryParse(File.ReadAllText(stagedUserIdFile, Encoding.UTF8), out ret)) {
-                        throw new Exception("File was read but contents were invalid");
-                    }
-
-                    return ret;
-                } catch (Exception ex) {
-                    this.Log().InfoException("Couldn't read staging user ID, creating a blank one", ex);
-                }
-
-                var prng = new Random();
-                var buf = new byte[4096];
-                prng.NextBytes(buf);
-
-                ret = Utility.CreateGuidFromHash(buf);
-                try {
-                    File.WriteAllText(stagedUserIdFile, ret.ToString(), Encoding.UTF8);
-                    return ret;
-                } catch (Exception ex) {
-                    this.Log().WarnException("Couldn't write out staging user ID, this user probably shouldn't get beta anything", ex);
-                    return null;
-                }
-            }
         }
     }
 }

--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -589,14 +589,18 @@ namespace Squirrel
         {
             return CreateGuidFromHash(text, Utility.IsoOidNamespace);
         }
-
+        public static Guid CreateGuidFromHash(byte[] data)
+        {
+            return CreateGuidFromHash(data, Utility.IsoOidNamespace);
+        }
 
         public static Guid CreateGuidFromHash(string text, Guid namespaceId)
         {
-            // convert the name to a sequence of octets (as defined by the standard 
-            // or conventions of its namespace) (step 3)
-            byte[] nameBytes = Encoding.UTF8.GetBytes(text);
+            return CreateGuidFromHash(Encoding.UTF8.GetBytes(text), namespaceId);
+        }
 
+        public static Guid CreateGuidFromHash(byte[] nameBytes, Guid namespaceId)
+        {
             // convert the namespace UUID to network order (step 3)
             byte[] namespaceBytes = namespaceId.ToByteArray();
             SwapByteOrder(namespaceBytes);

--- a/test/ReleaseEntryTests.cs
+++ b/test/ReleaseEntryTests.cs
@@ -88,6 +88,26 @@ namespace Squirrel.Tests.Core
             Assert.Equal(isDelta, fixture.IsDelta);
         }
 
+        [Theory]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2.nupkg                  123 # 10%", 1, 2, 0, 0, "", false, 0.1f)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2-full.nupkg             123 # 90%", 1, 2, 0, 0, "", false, 0.9f)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2-delta.nupkg            123", 1, 2, 0, 0, "", true, null)]
+        [InlineData("0000000000000000000000000000000000000000  MyCoolApp-1.2-delta.nupkg            123 # 5%", 1, 2, 0, 0, "", true, 0.05f)]
+        public void ParseStagingPercentageTest(string releaseEntry, int major, int minor, int patch, int revision, string prerelease, bool isDelta, float? stagingPercentage)
+        {
+            var fixture = ReleaseEntry.ParseReleaseEntry(releaseEntry);
+
+            Assert.Equal(new SemanticVersion(new Version(major, minor, patch, revision), prerelease), fixture.Version);
+            Assert.Equal(isDelta, fixture.IsDelta);
+
+            if (stagingPercentage.HasValue) {
+                Assert.True(Math.Abs(fixture.StagingPercentage.Value - stagingPercentage.Value) < 0.001);
+            } else {
+                Assert.Null(fixture.StagingPercentage);
+            }
+        }
+
+
         [Fact]
         public void CanParseGeneratedReleaseEntryAsString()
         {

--- a/test/ReleaseEntryTests.cs
+++ b/test/ReleaseEntryTests.cs
@@ -320,8 +320,6 @@ namespace Squirrel.Tests.Core
             Assert.Equal(3, releases.Length);
         }
 
-
-
         [Fact]
         public void ParseReleaseFileShouldReturnNothingForBlankFiles()
         {


### PR DESCRIPTION
This PR implements staged rollouts, where a certain percentage of your users will get the newest version of your app.

We do this by adding a magic comment to the RELEASES file - unfortunately, because of a bug in the syntax Regex in existing Squirrel.Windows versions, we have to write this in a super ugly way:

```
A3D8B15ABDB5F2A3D9FEBDB8F55B6D4FB8168828 atom-1.9.0-dev-4e74fb6-full.nupkg 110216564# 10%
```

Note that there is _no_ space between the filesize and the comment. In the future, you'll able to put a space there of course :)

## TODO:

- [x] Write some tests and what
- [x] Verify RELEASES format against old version of Squirrel.Windows
- [x] Verify case where we're not in the beta percentage
- [x] Rig beta ID, see us get put into the beta