### PR TITLE
Update the .nuspec dependencies

### DIFF
--- a/src/Squirrel.nuspec
+++ b/src/Squirrel.nuspec
@@ -9,7 +9,7 @@
     <iconUrl>https://raw.githubusercontent.com/Squirrel/Squirrel.Windows/master/docs/artwork/Squirrel-Logo-Square.png</iconUrl>
 
     <dependencies>
-      <dependency id="DeltaCompressionDotNet" version="1.0.0" />
+      <dependency id="DeltaCompressionDotNet" version="[1.0,2.0)" />
       <dependency id="Splat" version="1.6.2" />
       <dependency id="Mono.Cecil" version="0.9.6.1" />
     </dependencies>


### PR DESCRIPTION
Hi,

Squirrel seems to be a major user of my DeltaCompressionDotNet library. The current version is v1.1. I have a v2 I'd like to release with some small-but-breaking changes.

Squirrel's `.nuspec` depends on v1 *or higher* (see [here](https://docs.nuget.org/create/versioning) for more information).

This pull request changes the `.nuspec` to accept only v1-based versions of the library.

I'm not in any rush to release v2. So if you do accept this change I'm content to wait until Squirrel releases an updated NuGet package in advance of my own NuGet package.

Thanks.