### PR TITLE
fix: Uninstall not working if there is a space in the UninstallString

### DIFF
--- a/src/Squirrel/UpdateManager.InstallHelpers.cs
+++ b/src/Squirrel/UpdateManager.InstallHelpers.cs
@@ -135,7 +135,7 @@ namespace Squirrel
             public Task<RegistryKey> CreateUninstallerRegistryEntry()
             {
                 var updateDotExe = Path.Combine(rootAppDirectory, "Update.exe");
-                return CreateUninstallerRegistryEntry(String.Format("{0} --uninstall", updateDotExe), "-s");
+                return CreateUninstallerRegistryEntry(String.Format("\"{0}\" --uninstall", updateDotExe), "-s");
             }
 
             public void RemoveUninstallerRegistryEntry()


### PR DESCRIPTION
Closes #675 

Reproduced and confirmed that fix works (in my case space was in the app  name, not in the user name as in the original report).