### PR TITLE
Use entry exe path instead of Squirrel.dll when looking for Update.exe

### DIFF
--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -279,7 +279,7 @@ namespace Squirrel
                 return Path.GetFullPath(assembly.Location);
             }
 
-            assembly = Assembly.GetExecutingAssembly();
+            assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
 
             var updateDotExe = Path.Combine(Path.GetDirectoryName(assembly.Location), "..\\Update.exe");
             var target = new FileInfo(updateDotExe);


### PR DESCRIPTION
Currently, the documentation states that "The UpdateManager is expecting to find the Update.exe application installed one directory up from the EXE"; however this is currently not true. It is looking for Update.exe one directory above the Squirrel.dll, which may be commonly in an assemblies subdirectory. Using Assembly.GetEntryAssembly (with a fallback to the executing assembly in case of unmanaged code) allows for proper functioning.