### PR TITLE
Fix --processStart issues with <= 2.2.0

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -482,7 +482,7 @@ namespace Squirrel.Update
                 .FirstOrDefault(x => Directory.Exists(x));
 
             // Check for the EXE name they want
-            var targetExe = new FileInfo(Path.Combine(latestAppDir, exeName));
+            var targetExe = new FileInfo(Path.Combine(latestAppDir, exeName.Replace("%20", " ")));
             this.Log().Info("Want to launch '{0}'", targetExe);
 
             // Check for path canonicalization attacks


### PR DESCRIPTION
Replace %20 with spaces in versions above 2.2.0 so when launching shortcuts created in <= 2.2.0 we can still find the exe.

Fixes electron/windows-installer/issues/78

/cc @paulcbetts 