### PR TITLE
Patch to address the issue of moving directories with Antivirus Scan

### DIFF
--- a/src/Squirrel/UpdateInfo.cs
+++ b/src/Squirrel/UpdateInfo.cs
@@ -36,6 +36,7 @@ namespace Squirrel
 
         public Dictionary<ReleaseEntry, string> FetchReleaseNotes()
         {
+            this.Log().Info("Fetching release notes");
             return ReleasesToApply
                 .SelectMany(x => {
                     try {
@@ -43,7 +44,7 @@ namespace Squirrel
                         return EnumerableExtensions.Return(Tuple.Create(x, releaseNotes));
                     } catch (Exception ex) {
                         this.Log().WarnException("Couldn't get release notes for:" + x.Filename, ex);
-                        return Enumerable.Empty<Tuple<ReleaseEntry, string>>();
+                        return EnumerableExtensions.Return(Tuple.Create(x, String.Empty));
                     }
                 })
                 .ToDictionary(k => k.Item1, v => v.Item2);

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -399,6 +399,9 @@ namespace Squirrel.Update
             var writeZipToSetup = findExecutable("WriteZipToSetup.exe");
 
             try {
+                this.Log().Info("targetSetupExe: {0}", targetSetupExe);
+                this.Log().Info("zipPath {0}", zipPath);
+                this.Log().Info("writeZipToSetup {0}", writeZipToSetup);
                 var result = Utility.InvokeProcessAsync(writeZipToSetup, String.Format("\"{0}\" \"{1}\"", targetSetupExe, zipPath), CancellationToken.None).Result;
                 if (result.Item1 != 0) throw new Exception("Failed to write Zip to Setup.exe!\n\n" + result.Item2);
             } catch (Exception ex) {


### PR DESCRIPTION
This pull request is a 'patch' to address the problem seen when installing on a system with antivirus scan.

**The problem**
As part of the installation process, the .nupkg is unpacked in a temp directory, and then some of the directories under that package are moved to the final place where they have to be installed.
When the system has an antivirus scan, sometimes that move fails, because some of teh files in the directories that have to be moved may be being scanned by the scanner, and that causes the move to fail because the files are in use.

**The "solution"**
The change makes the install process resilient to this situation, by trying several times the move before issuing an error. 
I know that the fix is not very elegant (sorry, I am not an expert in c# programming), but it has worked on the cases we had problems installing the application that we are developping