### PR TITLE
Extract Zip file in-place

### DIFF
--- a/src/SolutionAssemblyInfo.cs
+++ b/src/SolutionAssemblyInfo.cs
@@ -25,4 +25,4 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("1.4.0")]
+[assembly: AssemblyVersion("1.4.1")]

--- a/src/Squirrel/ReleasePackage.cs
+++ b/src/Squirrel/ReleasePackage.cs
@@ -202,11 +202,11 @@ namespace Squirrel
 
                     var entryFileName = Uri.UnescapeDataString(zipEntry.Name);
                     var fullZipToPath = Path.Combine(outFolder, entryFileName);
-                    fullZipToPath = re.Replace(fullZipToPath, "", 1);
 
                     var directoryName = Path.GetDirectoryName(fullZipToPath);
 
-                    if (directoryFilter.IsMatch(directoryName)) return;
+                    if (!directoryFilter.IsMatch(directoryName)) return;
+                    fullZipToPath = re.Replace(fullZipToPath, "", 1);
 
                     var buffer = new byte[64*1024];
 

--- a/src/Squirrel/ReleasePackage.cs
+++ b/src/Squirrel/ReleasePackage.cs
@@ -206,7 +206,8 @@ namespace Squirrel
                     var directoryName = Path.GetDirectoryName(fullZipToPath);
 
                     if (!directoryFilter.IsMatch(directoryName)) return;
-                    fullZipToPath = re.Replace(fullZipToPath, "", 1);
+                    fullZipToPath = re.Replace(fullZipToPath, "");
+                    directoryName = re.Replace(directoryName, "");
 
                     var buffer = new byte[64*1024];
 

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -289,34 +289,10 @@ namespace Squirrel
                     target.Create();
 
                     this.Log().Info("Writing files to app directory: {0}", target.FullName);
-                    ReleasePackage.ExtractZipDecoded(Path.Combine(updateInfo.PackageDirectory, release.Filename),
-                        target.FullName, @"lib");
+                    await ReleasePackage.ExtractZipForInstall(
+                        Path.Combine(updateInfo.PackageDirectory, release.Filename),
+                        target.FullName);
 
-                    // Move all of the files out of the lib/ dirs in the NuGet package
-                    // into our target App directory.
-                    //
-                    // NB: We sort this list in order to guarantee that if a Net20
-                    // and a Net40 version of a DLL get shipped, we always end up
-                    // with the 4.0 version.
-                    var libDir = target.GetDirectories().First(x => x.Name.Equals("lib", StringComparison.OrdinalIgnoreCase));
-                    var toMove = libDir.GetDirectories().OrderBy(x => x.Name);
-
-                    toMove.ForEach(ld => {
-                        ld.GetDirectories()
-                            .ForEachAsync(subdir => subdir.MoveTo(subdir.FullName.Replace(ld.FullName, target.FullName)))
-                            .Wait();
-
-                        ld.GetFiles()
-                            .ForEachAsync(file => {
-                                var tgt = Path.Combine(target.FullName, file.Name);
-                                this.Log().Info("Moving file {0} to {1}", file.FullName, tgt);
-                                if (File.Exists(tgt)) Utility.DeleteFileHarder(tgt, true);
-                                file.MoveTo(tgt);
-                            })
-                            .Wait();
-                    });
-
-                    await Utility.DeleteDirectory(libDir.FullName);
                     return target.FullName;
                 });
             }

--- a/test/ApplyReleasesTests.cs
+++ b/test/ApplyReleasesTests.cs
@@ -165,7 +165,7 @@ namespace Squirrel.Tests
 
                 Assert.False(File.Exists(Path.Combine(tempDir, "theApp", "app-0.1.0", "args.txt")));
                 Assert.False(File.Exists(Path.Combine(tempDir, "theApp", "app-0.2.0", "args.txt")));
-                Assert.True(File.Exists(Path.Combine(tempDir, "theApp", "app-0.2.0", ".dead")));
+                Assert.True(File.Exists(Path.Combine(tempDir, "theApp", ".dead")));
             }
         }
 


### PR DESCRIPTION
Extracting an executable then immediately trying to move it is a recipe for disaster. Instead, extract it to the correct place the first time around.

## TODO:

- [ ] Make sure this works