### PR TITLE
Update 1-integrating.md

### DIFF
--- a/docs/getting-started/1-integrating.md
+++ b/docs/getting-started/1-integrating.md
@@ -36,7 +36,7 @@ The following code is added to MyApp `Program.cs` to cause the application to ch
 using Squirrel;
 ~~~
 
-**`static void Main()`**
+**`static void UpdateApp()`**
 
 ~~~cs
 using (var mgr = new UpdateManager("C:\\Projects\\MyApp\\Releases"))


### PR DESCRIPTION
"await" may only be used in methods marked as async. The Main() method (entry point) cannot be async, because when Main() returns, the application usually terminates.