### PR TITLE
Perform tests against zip path first to help with long paths

### DIFF
--- a/src/Squirrel/ReleasePackage.cs
+++ b/src/Squirrel/ReleasePackage.cs
@@ -192,7 +192,6 @@ namespace Squirrel
         public static async Task ExtractZipForInstall(string zipFilePath, string outFolder)
         {
             var zf = new ZipFile(zipFilePath);
-            var directoryFilter = new NameFilter("lib");
             var entries = zf.OfType<ZipEntry>().ToArray();
             var re = new Regex(@"lib[\\\/][^\\\/]*[\\\/]", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
@@ -201,13 +200,10 @@ namespace Squirrel
                     if (!zipEntry.IsFile) return;
 
                     var entryFileName = Uri.UnescapeDataString(zipEntry.Name);
-                    var fullZipToPath = Path.Combine(outFolder, entryFileName);
+                    if (!re.Match(entryFileName).Success) return;
 
+                    var fullZipToPath = Path.Combine(outFolder, re.Replace(entryFileName, "", 1));
                     var directoryName = Path.GetDirectoryName(fullZipToPath);
-
-                    if (!directoryFilter.IsMatch(directoryName)) return;
-                    fullZipToPath = re.Replace(fullZipToPath, "", 1);
-                    directoryName = re.Replace(directoryName, "", 1);
 
                     var buffer = new byte[64*1024];
 


### PR DESCRIPTION
This tests the zip entry path against the regex to determine whether it is in the lib folder and should be extracted or not.

Previously the code was using the full path which causes paths that were already close to the limit to go over as it also has lib\net45 etc in it.  It also seems that the old code would extract files it shouldn't if the word "lib" appeared in the output path, e.g. `c:\users\libby`)
