### PR TITLE
Set ToastActivatorCLSID during shortcut creation

### DIFF
--- a/src/Squirrel/ShellFile.cs
+++ b/src/Squirrel/ShellFile.cs
@@ -85,6 +85,15 @@ namespace Squirrel.Shell
                     };
                 }
             }
+
+            public static PROPERTYKEY PKEY_AppUserModel_ToastActivatorCLSID {
+                get {
+                    return new PROPERTYKEY() {
+                        fmtid = Guid.ParseExact("{9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}", "B"),
+                        pid = new UIntPtr(26),
+                    };
+                }
+            }
         }
 
         [ComImport]
@@ -861,11 +870,25 @@ namespace Squirrel.Shell
             }
         }
 
+        /// <summary>
+        /// Sets the appUserModelId
+        /// </summary>
         public void SetAppUserModelId(string appId)
         {
             var propStore = (IPropertyStore)linkW;
             var pkey = PROPERTYKEY.PKEY_AppUserModel_ID;
             var str = PropVariant.FromString (appId);
+            propStore.SetValue(ref pkey, ref str);
+        }
+
+        /// <summary>
+        /// Sets the ToastActivatorCLSID
+        /// </summary>
+        public void SetToastActivatorCLSID(string clsid)
+        {
+            var propStore = (IPropertyStore)linkW;
+            var pkey = PROPERTYKEY.PKEY_AppUserModel_ToastActivatorCLSID;
+            var str = PropVariant.FromString (clsid);
             propStore.SetValue(ref pkey, ref str);
         }
 

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -165,8 +165,11 @@ namespace Squirrel
                     if (!locations.HasFlag(f)) continue;
 
                     var file = linkTargetForVersionInfo(f, zf, fileVerInfo);
+                    var appUserModelId = String.Format("com.squirrel.{0}.{1}", zf.Id.Replace(" ", ""), exeName.Replace(".exe", "").Replace(" ", ""));
+                    var toastActivatorCLSDID = Utility.CreateGuidFromHash(appUserModelId).ToString();
 
                     this.Log().Info("Creating shortcut for {0} => {1}", exeName, file);
+                    this.Log().Info("appUserModelId: {0} | toastActivatorCLSID: {1}", appUserModelId, toastActivatorCLSDID);
 
                     ShellLink sl;
                     sl = new ShellLink {
@@ -182,7 +185,9 @@ namespace Squirrel
                         sl.Arguments += String.Format(" -a \"{0}\"", programArguments);
                     }
 
-                    sl.SetAppUserModelId(String.Format("com.squirrel.{0}.{1}", zf.Id.Replace(" ", ""), exeName.Replace(".exe", "").Replace(" ", "")));
+                    sl.SetAppUserModelId(appUserModelId);
+                    sl.SetToastActivatorCLSID(toastActivatorCLSDID);
+
                     ret.Add(f, sl);
                 }
 
@@ -238,9 +243,13 @@ namespace Squirrel
                             sl.Arguments += String.Format(" -a \"{0}\"", programArguments);
                         }
 
-                        sl.SetAppUserModelId(String.Format("com.squirrel.{0}.{1}", zf.Id.Replace(" ", ""), exeName.Replace(".exe", "").Replace(" ", "")));
+                        var appUserModelId = String.Format("com.squirrel.{0}.{1}", zf.Id.Replace(" ", ""), exeName.Replace(".exe", "").Replace(" ", ""));
+                        var toastActivatorCLSID = Utility.CreateGuidFromHash(appUserModelId).ToString();
 
-                        this.Log().Info("About to save shortcut: {0} (target {1}, workingDir {2}, args {3})", file, sl.Target, sl.WorkingDirectory, sl.Arguments);
+                        sl.SetAppUserModelId(appUserModelId);
+                        sl.SetToastActivatorCLSID(toastActivatorCLSID);
+
+                        this.Log().Info("About to save shortcut: {0} (target {1}, workingDir {2}, args {3}, toastActivatorCSLID {4})", file, sl.Target, sl.WorkingDirectory, sl.Arguments, toastActivatorCLSID);
                         if (ModeDetector.InUnitTestRunner() == false) sl.Save(file);
                     }, 4), "Can't write shortcut: " + file);
                 }


### PR DESCRIPTION
When creating a shortcut, Squirrel also sets `System.AppUserModel.Id` so that apps are able to interact with Windows in all kinds of ways. However, interactive toast notifications require a set `System.AppUserModel.ToastActivatorCLSID`. This small PR teaches Squirrel how to set said CLSID.

```
Name:     System.AppUserModel.ToastActivatorCLSID -- PKEY_AppUserModel_ToastActivatorCLSID
Type:     Guid -- VT_CLSID
FormatID: {9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}, 26
```