### PR TITLE
Fix for detecting squirrel aware app when Mono.Cecil does not detect Custom Attributes

### DIFF
--- a/src/Squirrel/SquirrelAwareExecutableDetector.cs
+++ b/src/Squirrel/SquirrelAwareExecutableDetector.cs
@@ -38,8 +38,8 @@ namespace Squirrel
             try {
                 var assembly = AssemblyDefinition.ReadAssembly(executable);
                 if (!assembly.HasCustomAttributes) {
-					return GetAssemblySquirrelAwareVersionUsingSystemReflections(executable);					
-				}
+		    return GetAssemblySquirrelAwareVersionUsingSystemReflections(executable);					
+		}
 
                 var attrs = assembly.CustomAttributes;
                 var attribute = attrs.FirstOrDefault(x => {

--- a/src/Squirrel/SquirrelAwareExecutableDetector.cs
+++ b/src/Squirrel/SquirrelAwareExecutableDetector.cs
@@ -38,8 +38,8 @@ namespace Squirrel
             try {
                 var assembly = AssemblyDefinition.ReadAssembly(executable);
                 if (!assembly.HasCustomAttributes) {
-		    return GetAssemblySquirrelAwareVersionUsingSystemReflections(executable);					
-		}
+					return GetAssemblySquirrelAwareVersionUsingSystemReflections(executable);					
+				}
 
                 var attrs = assembly.CustomAttributes;
                 var attribute = attrs.FirstOrDefault(x => {

--- a/src/Squirrel/SquirrelAwareExecutableDetector.cs
+++ b/src/Squirrel/SquirrelAwareExecutableDetector.cs
@@ -37,7 +37,33 @@ namespace Squirrel
         {
             try {
                 var assembly = AssemblyDefinition.ReadAssembly(executable);
-                if (!assembly.HasCustomAttributes) return null;
+                if (!assembly.HasCustomAttributes) return GetAssemblySquirrelAwareVersionUsingSystemReflections(executable);
+
+                var attrs = assembly.CustomAttributes;
+                var attribute = attrs.FirstOrDefault(x => {
+                    if (x.AttributeType.FullName != typeof(AssemblyMetadataAttribute).FullName) return false;
+                    if (x.ConstructorArguments.Count != 2) return false;
+                    return x.ConstructorArguments[0].Value.ToString() == "SquirrelAwareVersion";
+                });
+
+                if (attribute == null) return null;
+
+                int result;
+                if (!Int32.TryParse(attribute.ConstructorArguments[1].Value.ToString(), NumberStyles.Integer, CultureInfo.CurrentCulture, out result)) {
+                    return null;
+                }
+
+                return result;
+            } 
+            catch (FileLoadException) { return null; }
+            catch (BadImageFormatException) { return null; }
+        }
+        
+        static int? GetAssemblySquirrelAwareVersionUsingSystemReflections(string executable)
+        {
+            try {
+                var assembly = Assembly.LoadFile(executable);
+                if (assembly.CustomAttributes.Count() <= 0) return null;
 
                 var attrs = assembly.CustomAttributes;
                 var attribute = attrs.FirstOrDefault(x => {

--- a/src/Squirrel/SquirrelAwareExecutableDetector.cs
+++ b/src/Squirrel/SquirrelAwareExecutableDetector.cs
@@ -94,6 +94,7 @@ namespace Squirrel
 	    
 		static int? GetAssemblySquirrelAwareVersionUsingSystemReflections(string executable)
 		{
+			
 			try {
 				var assembly = Assembly.LoadFile(executable);
 				if (assembly.CustomAttributes.Count() <= 0) return null;

--- a/src/Squirrel/SquirrelAwareExecutableDetector.cs
+++ b/src/Squirrel/SquirrelAwareExecutableDetector.cs
@@ -38,8 +38,8 @@ namespace Squirrel
             try {
                 var assembly = AssemblyDefinition.ReadAssembly(executable);
                 if (!assembly.HasCustomAttributes) {
-					return GetAssemblySquirrelAwareVersionUsingSystemReflections(executable);					
-				}
+			return GetAssemblySquirrelAwareVersionUsingSystemReflections(executable);					
+		}
 
                 var attrs = assembly.CustomAttributes;
                 var attribute = attrs.FirstOrDefault(x => {
@@ -60,35 +60,7 @@ namespace Squirrel
             catch (FileLoadException) { return null; }
             catch (BadImageFormatException) { return null; }
         }
-		
-		static int? GetAssemblySquirrelAwareVersionUsingSystemReflections(string executable)
-		{
-			try {
-				var assembly = Assembly.LoadFile(executable);
-				if (assembly.CustomAttributes.Count() <= 0) return null;
-
-				var attrs = assembly.CustomAttributes;
-				var attribute = attrs.FirstOrDefault(x =>
-				{
-				   if (x.AttributeType.FullName != typeof(AssemblyMetadataAttribute).FullName) return false;
-				   if (x.ConstructorArguments.Count != 2) return false;
-				   return x.ConstructorArguments[0].Value.ToString() == "SquirrelAwareVersion";
-				});
-
-				if (attribute == null) return null;
-
-				int result;
-				if (!Int32.TryParse(attribute.ConstructorArguments[1].Value.ToString(), NumberStyles.Integer, CultureInfo.CurrentCulture, out result))
-				{
-				   return null;
-				}
-
-				return result;
-			}
-			catch (FileLoadException) { return null; }
-			catch (BadImageFormatException) { return null; }
-		}
-
+	
         static int? GetVersionBlockSquirrelAwareValue(string executable)
         {
             int size = NativeMethods.GetFileVersionInfoSize(executable, IntPtr.Zero);
@@ -119,5 +91,33 @@ namespace Squirrel
             return ret;
 #endif
         }
+	    
+		static int? GetAssemblySquirrelAwareVersionUsingSystemReflections(string executable)
+		{
+			try {
+				var assembly = Assembly.LoadFile(executable);
+				if (assembly.CustomAttributes.Count() <= 0) return null;
+
+				var attrs = assembly.CustomAttributes;
+				var attribute = attrs.FirstOrDefault(x =>
+				{
+				   if (x.AttributeType.FullName != typeof(AssemblyMetadataAttribute).FullName) return false;
+				   if (x.ConstructorArguments.Count != 2) return false;
+				   return x.ConstructorArguments[0].Value.ToString() == "SquirrelAwareVersion";
+				});
+
+				if (attribute == null) return null;
+
+				int result;
+				if (!Int32.TryParse(attribute.ConstructorArguments[1].Value.ToString(), NumberStyles.Integer, CultureInfo.CurrentCulture, out result))
+				{
+				   return null;
+				}
+
+				return result;
+			}
+			catch (FileLoadException) { return null; }
+			catch (BadImageFormatException) { return null; }
+		}
     }
 }

--- a/src/Squirrel/SquirrelAwareExecutableDetector.cs
+++ b/src/Squirrel/SquirrelAwareExecutableDetector.cs
@@ -11,111 +11,105 @@ using Mono.Cecil;
 
 namespace Squirrel
 {
-   static class SquirrelAwareExecutableDetector
-   {
-      public static List<string> GetAllSquirrelAwareApps(string directory, int minimumVersion = 1)
-      {
-         var di = new DirectoryInfo(directory);
+    static class SquirrelAwareExecutableDetector
+    {
+        public static List<string> GetAllSquirrelAwareApps(string directory, int minimumVersion = 1)
+        {
+            var di = new DirectoryInfo(directory);
 
-         return di.EnumerateFiles()
-             .Where(x => x.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
-             .Select(x => x.FullName)
-             .Where(x => (GetPESquirrelAwareVersion(x) ?? -1) >= minimumVersion)
-             .ToList();
-      }
+            return di.EnumerateFiles()
+                .Where(x => x.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                .Select(x => x.FullName)
+                .Where(x => (GetPESquirrelAwareVersion(x) ?? -1) >= minimumVersion)
+                .ToList();
+        }
 
-      public static int? GetPESquirrelAwareVersion(string executable)
-      {
-         if (!File.Exists(executable)) return null;
-         var fullname = Path.GetFullPath(executable);
+        public static int? GetPESquirrelAwareVersion(string executable)
+        {
+            if (!File.Exists(executable)) return null;
+            var fullname = Path.GetFullPath(executable);
 
-         return Utility.Retry<int?>(() =>
-             GetAssemblySquirrelAwareVersion(fullname) ?? GetVersionBlockSquirrelAwareValue(fullname));
-      }
+            return Utility.Retry<int?>(() => 
+                GetAssemblySquirrelAwareVersion(fullname) ?? GetVersionBlockSquirrelAwareValue(fullname));
+        }
 
-      static int? GetAssemblySquirrelAwareVersion(string executable)
-      {
-         try
-         {
-            var assembly = AssemblyDefinition.ReadAssembly(executable);
-            if (!assembly.HasCustomAttributes)
-            {
-               return GetAssemblySquirrelAwareVersionUsingSystemReflections(executable);
+        static int? GetAssemblySquirrelAwareVersion(string executable)
+        {
+            try {
+                var assembly = AssemblyDefinition.ReadAssembly(executable);
+                if (!assembly.HasCustomAttributes) {
+					return GetAssemblySquirrelAwareVersionUsingSystemReflections(executable);					
+				}
+
+                var attrs = assembly.CustomAttributes;
+                var attribute = attrs.FirstOrDefault(x => {
+                    if (x.AttributeType.FullName != typeof(AssemblyMetadataAttribute).FullName) return false;
+                    if (x.ConstructorArguments.Count != 2) return false;
+                    return x.ConstructorArguments[0].Value.ToString() == "SquirrelAwareVersion";
+                });
+
+                if (attribute == null) return null;
+
+                int result;
+                if (!Int32.TryParse(attribute.ConstructorArguments[1].Value.ToString(), NumberStyles.Integer, CultureInfo.CurrentCulture, out result)) {
+                    return null;
+                }
+
+                return result;
+            } 
+            catch (FileLoadException) { return null; }
+            catch (BadImageFormatException) { return null; }
+        }
+		
+		static int? GetAssemblySquirrelAwareVersionUsingSystemReflections(string executable)
+		{
+			try {
+				var assembly = Assembly.LoadFile(executable);
+				if (assembly.CustomAttributes.Count() <= 0) return null;
+
+				var attrs = assembly.CustomAttributes;
+				var attribute = attrs.FirstOrDefault(x =>
+				{
+				   if (x.AttributeType.FullName != typeof(AssemblyMetadataAttribute).FullName) return false;
+				   if (x.ConstructorArguments.Count != 2) return false;
+				   return x.ConstructorArguments[0].Value.ToString() == "SquirrelAwareVersion";
+				});
+
+				if (attribute == null) return null;
+
+				int result;
+				if (!Int32.TryParse(attribute.ConstructorArguments[1].Value.ToString(), NumberStyles.Integer, CultureInfo.CurrentCulture, out result))
+				{
+				   return null;
+				}
+
+				return result;
+			}
+			catch (FileLoadException) { return null; }
+			catch (BadImageFormatException) { return null; }
+		}
+
+        static int? GetVersionBlockSquirrelAwareValue(string executable)
+        {
+            int size = NativeMethods.GetFileVersionInfoSize(executable, IntPtr.Zero);
+
+            // Nice try, buffer overflow
+            if (size <= 0 || size > 4096) return null;
+
+            var buf = new byte[size];
+            if (!NativeMethods.GetFileVersionInfo(executable, IntPtr.Zero, size, buf)) return null;
+
+            IntPtr result; int resultSize;
+            if (!NativeMethods.VerQueryValue(buf, "\\StringFileInfo\\040904B0\\SquirrelAwareVersion", out result, out resultSize)) {
+                return null;
             }
 
-            var attrs = assembly.CustomAttributes;
-            var attribute = attrs.FirstOrDefault(x =>
-            {
-               if (x.AttributeType.FullName != typeof(AssemblyMetadataAttribute).FullName) return false;
-               if (x.ConstructorArguments.Count != 2) return false;
-               return x.ConstructorArguments[0].Value.ToString() == "SquirrelAwareVersion";
-            });
-
-            if (attribute == null) return null;
-
-            int result;
-            if (!Int32.TryParse(attribute.ConstructorArguments[1].Value.ToString(), NumberStyles.Integer, CultureInfo.CurrentCulture, out result))
-            {
-               return null;
-            }
-
-            return result;
-         }
-         catch (FileLoadException) { return null; }
-         catch (BadImageFormatException) { return null; }
-      }
-
-      static int? GetAssemblySquirrelAwareVersionUsingSystemReflections(string executable)
-      {
-         try
-         {
-            var assembly = Assembly.LoadFile(executable);
-            if (assembly.CustomAttributes.Count() <= 0) return null;
-
-            var attrs = assembly.CustomAttributes;
-            var attribute = attrs.FirstOrDefault(x =>
-            {
-               if (x.AttributeType.FullName != typeof(AssemblyMetadataAttribute).FullName) return false;
-               if (x.ConstructorArguments.Count != 2) return false;
-               return x.ConstructorArguments[0].Value.ToString() == "SquirrelAwareVersion";
-            });
-
-            if (attribute == null) return null;
-
-            int result;
-            if (!Int32.TryParse(attribute.ConstructorArguments[1].Value.ToString(), NumberStyles.Integer, CultureInfo.CurrentCulture, out result))
-            {
-               return null;
-            }
-
-            return result;
-         }
-         catch (FileLoadException) { return null; }
-         catch (BadImageFormatException) { return null; }
-      }
-
-      static int? GetVersionBlockSquirrelAwareValue(string executable)
-      {
-         int size = NativeMethods.GetFileVersionInfoSize(executable, IntPtr.Zero);
-
-         // Nice try, buffer overflow
-         if (size <= 0 || size > 4096) return null;
-
-         var buf = new byte[size];
-         if (!NativeMethods.GetFileVersionInfo(executable, IntPtr.Zero, size, buf)) return null;
-
-         IntPtr result; int resultSize;
-         if (!NativeMethods.VerQueryValue(buf, "\\StringFileInfo\\040904B0\\SquirrelAwareVersion", out result, out resultSize))
-         {
-            return null;
-         }
-
-         // NB: I have **no** idea why, but Atom.exe won't return the version
-         // number "1" despite it being in the resource file and being 100% 
-         // identical to the version block that actually works. I've got stuff
-         // to ship, so we're just going to return '1' if we find the name in 
-         // the block at all. I hate myself for this.
-         return 1;
+            // NB: I have **no** idea why, but Atom.exe won't return the version
+            // number "1" despite it being in the resource file and being 100% 
+            // identical to the version block that actually works. I've got stuff
+            // to ship, so we're just going to return '1' if we find the name in 
+            // the block at all. I hate myself for this.
+            return 1;
 
 #if __NOT__DEFINED_EVAR__
             int ret;
@@ -124,6 +118,6 @@ namespace Squirrel
 
             return ret;
 #endif
-      }
-   }
+        }
+    }
 }

--- a/src/Squirrel/SquirrelAwareExecutableDetector.cs
+++ b/src/Squirrel/SquirrelAwareExecutableDetector.cs
@@ -11,75 +11,111 @@ using Mono.Cecil;
 
 namespace Squirrel
 {
-    static class SquirrelAwareExecutableDetector
-    {
-        public static List<string> GetAllSquirrelAwareApps(string directory, int minimumVersion = 1)
-        {
-            var di = new DirectoryInfo(directory);
+   static class SquirrelAwareExecutableDetector
+   {
+      public static List<string> GetAllSquirrelAwareApps(string directory, int minimumVersion = 1)
+      {
+         var di = new DirectoryInfo(directory);
 
-            return di.EnumerateFiles()
-                .Where(x => x.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
-                .Select(x => x.FullName)
-                .Where(x => (GetPESquirrelAwareVersion(x) ?? -1) >= minimumVersion)
-                .ToList();
-        }
+         return di.EnumerateFiles()
+             .Where(x => x.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+             .Select(x => x.FullName)
+             .Where(x => (GetPESquirrelAwareVersion(x) ?? -1) >= minimumVersion)
+             .ToList();
+      }
 
-        public static int? GetPESquirrelAwareVersion(string executable)
-        {
-            if (!File.Exists(executable)) return null;
-            var fullname = Path.GetFullPath(executable);
+      public static int? GetPESquirrelAwareVersion(string executable)
+      {
+         if (!File.Exists(executable)) return null;
+         var fullname = Path.GetFullPath(executable);
 
-            return Utility.Retry<int?>(() => 
-                GetAssemblySquirrelAwareVersion(fullname) ?? GetVersionBlockSquirrelAwareValue(fullname));
-        }
+         return Utility.Retry<int?>(() =>
+             GetAssemblySquirrelAwareVersion(fullname) ?? GetVersionBlockSquirrelAwareValue(fullname));
+      }
 
-        static int? GetAssemblySquirrelAwareVersion(string executable)
-        {
-            try {
-                var assembly = AssemblyDefinition.ReadAssembly(executable);
-                if (!assembly.HasCustomAttributes) return null;
-
-                var attrs = assembly.CustomAttributes;
-                var attribute = attrs.FirstOrDefault(x => {
-                    if (x.AttributeType.FullName != typeof(AssemblyMetadataAttribute).FullName) return false;
-                    if (x.ConstructorArguments.Count != 2) return false;
-                    return x.ConstructorArguments[0].Value.ToString() == "SquirrelAwareVersion";
-                });
-
-                if (attribute == null) return null;
-
-                int result;
-                if (!Int32.TryParse(attribute.ConstructorArguments[1].Value.ToString(), NumberStyles.Integer, CultureInfo.CurrentCulture, out result)) {
-                    return null;
-                }
-
-                return result;
-            } 
-            catch (FileLoadException) { return null; }
-            catch (BadImageFormatException) { return null; }
-        }
-
-        static int? GetVersionBlockSquirrelAwareValue(string executable)
-        {
-            int size = NativeMethods.GetFileVersionInfoSize(executable, IntPtr.Zero);
-
-            // Nice try, buffer overflow
-            if (size <= 0 || size > 4096) return null;
-
-            var buf = new byte[size];
-            if (!NativeMethods.GetFileVersionInfo(executable, IntPtr.Zero, size, buf)) return null;
-
-            IntPtr result; int resultSize;
-            if (!NativeMethods.VerQueryValue(buf, "\\StringFileInfo\\040904B0\\SquirrelAwareVersion", out result, out resultSize)) {
-                return null;
+      static int? GetAssemblySquirrelAwareVersion(string executable)
+      {
+         try
+         {
+            var assembly = AssemblyDefinition.ReadAssembly(executable);
+            if (!assembly.HasCustomAttributes)
+            {
+               return GetAssemblySquirrelAwareVersionUsingSystemReflections(executable);
             }
 
-            // NB: I have **no** idea why, but Atom.exe won't return the version
-            // number "1" despite it being in the resource file and being 100% 
-            // identical to the version block that actually works. I've got stuff
-            // to ship, so we're just going to return '1' if we find the name in 
-            // the block at all. I hate myself for this.
-            return 1;
+            var attrs = assembly.CustomAttributes;
+            var attribute = attrs.FirstOrDefault(x =>
+            {
+               if (x.AttributeType.FullName != typeof(AssemblyMetadataAttribute).FullName) return false;
+               if (x.ConstructorArguments.Count != 2) return false;
+               return x.ConstructorArguments[0].Value.ToString() == "SquirrelAwareVersion";
+            });
+
+            if (attribute == null) return null;
+
+            int result;
+            if (!Int32.TryParse(attribute.ConstructorArguments[1].Value.ToString(), NumberStyles.Integer, CultureInfo.CurrentCulture, out result))
+            {
+               return null;
+            }
+
+            return result;
+         }
+         catch (FileLoadException) { return null; }
+         catch (BadImageFormatException) { return null; }
+      }
+
+      static int? GetAssemblySquirrelAwareVersionUsingSystemReflections(string executable)
+      {
+         try
+         {
+            var assembly = Assembly.LoadFile(executable);
+            if (assembly.CustomAttributes.Count() <= 0) return null;
+
+            var attrs = assembly.CustomAttributes;
+            var attribute = attrs.FirstOrDefault(x =>
+            {
+               if (x.AttributeType.FullName != typeof(AssemblyMetadataAttribute).FullName) return false;
+               if (x.ConstructorArguments.Count != 2) return false;
+               return x.ConstructorArguments[0].Value.ToString() == "SquirrelAwareVersion";
+            });
+
+            if (attribute == null) return null;
+
+            int result;
+            if (!Int32.TryParse(attribute.ConstructorArguments[1].Value.ToString(), NumberStyles.Integer, CultureInfo.CurrentCulture, out result))
+            {
+               return null;
+            }
+
+            return result;
+         }
+         catch (FileLoadException) { return null; }
+         catch (BadImageFormatException) { return null; }
+      }
+
+      static int? GetVersionBlockSquirrelAwareValue(string executable)
+      {
+         int size = NativeMethods.GetFileVersionInfoSize(executable, IntPtr.Zero);
+
+         // Nice try, buffer overflow
+         if (size <= 0 || size > 4096) return null;
+
+         var buf = new byte[size];
+         if (!NativeMethods.GetFileVersionInfo(executable, IntPtr.Zero, size, buf)) return null;
+
+         IntPtr result; int resultSize;
+         if (!NativeMethods.VerQueryValue(buf, "\\StringFileInfo\\040904B0\\SquirrelAwareVersion", out result, out resultSize))
+         {
+            return null;
+         }
+
+         // NB: I have **no** idea why, but Atom.exe won't return the version
+         // number "1" despite it being in the resource file and being 100% 
+         // identical to the version block that actually works. I've got stuff
+         // to ship, so we're just going to return '1' if we find the name in 
+         // the block at all. I hate myself for this.
+         return 1;
 
 #if __NOT__DEFINED_EVAR__
             int ret;
@@ -88,6 +124,6 @@ namespace Squirrel
 
             return ret;
 #endif
-        }
-    }
+      }
+   }
 }

--- a/src/Squirrel/SquirrelAwareExecutableDetector.cs
+++ b/src/Squirrel/SquirrelAwareExecutableDetector.cs
@@ -37,9 +37,7 @@ namespace Squirrel
         {
             try {
                 var assembly = AssemblyDefinition.ReadAssembly(executable);
-                if (!assembly.HasCustomAttributes) {
-			return GetAssemblySquirrelAwareVersionUsingSystemReflections(executable);					
-		}
+                if (!assembly.HasCustomAttributes) return null;
 
                 var attrs = assembly.CustomAttributes;
                 var attribute = attrs.FirstOrDefault(x => {
@@ -60,7 +58,7 @@ namespace Squirrel
             catch (FileLoadException) { return null; }
             catch (BadImageFormatException) { return null; }
         }
-	
+
         static int? GetVersionBlockSquirrelAwareValue(string executable)
         {
             int size = NativeMethods.GetFileVersionInfoSize(executable, IntPtr.Zero);
@@ -91,34 +89,5 @@ namespace Squirrel
             return ret;
 #endif
         }
-	    
-		static int? GetAssemblySquirrelAwareVersionUsingSystemReflections(string executable)
-		{
-			
-			try {
-				var assembly = Assembly.LoadFile(executable);
-				if (assembly.CustomAttributes.Count() <= 0) return null;
-
-				var attrs = assembly.CustomAttributes;
-				var attribute = attrs.FirstOrDefault(x =>
-				{
-				   if (x.AttributeType.FullName != typeof(AssemblyMetadataAttribute).FullName) return false;
-				   if (x.ConstructorArguments.Count != 2) return false;
-				   return x.ConstructorArguments[0].Value.ToString() == "SquirrelAwareVersion";
-				});
-
-				if (attribute == null) return null;
-
-				int result;
-				if (!Int32.TryParse(attribute.ConstructorArguments[1].Value.ToString(), NumberStyles.Integer, CultureInfo.CurrentCulture, out result))
-				{
-				   return null;
-				}
-
-				return result;
-			}
-			catch (FileLoadException) { return null; }
-			catch (BadImageFormatException) { return null; }
-		}
     }
 }


### PR DESCRIPTION
Installation and Updation was working fine until exe was not executed through ConfuserEx.

When exe was processed by ConfuserEx; shortcuts was created for all exe in folder.
The reason was Mono.Cecil says no custom attributes.
When used system.reflection; custom attributes was detected successfully.

jbevain/cecil#305