### PR TITLE
Fixed semenatic versioning regex to support uppercase characters.

### DIFF
--- a/src/Squirrel/ReleaseExtensions.cs
+++ b/src/Squirrel/ReleaseExtensions.cs
@@ -11,7 +11,7 @@ namespace Squirrel
     public static class VersionExtensions
     {
         static readonly Regex _suffixRegex = new Regex(@"(-full|-delta)?\.nupkg$", RegexOptions.Compiled);
-        static readonly Regex _versionRegex = new Regex(@"\d+(\.\d+){0,3}(-[a-z][0-9a-z-]*)?$", RegexOptions.Compiled);
+        static readonly Regex _versionRegex = new Regex(@"\d+(\.\d+){0,3}(-[A-Za-z][0-9A-Za-z-]*)?$", RegexOptions.Compiled);
 
         public static SemanticVersion ToSemanticVersion(this IReleasePackage package)
         {


### PR DESCRIPTION
From SemVer 1.0: http://semver.org/spec/v1.0.0.html
The string MUST be comprised of only alphanumerics plus dash [0-9A-Za-z-]. Pre-release versions satisfy but have a lower precedence than the associated normal version.