### PR TITLE
Ensure a console has been allocated before using it

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -31,9 +31,10 @@ namespace Squirrel.Update
             try {
                 return pg.main(args);
             } catch (Exception ex) {
+                ensureConsole();
+                Console.Error.WriteLine(ex);
                 // NB: Normally this is a terrible idea but we want to make
                 // sure Setup.exe above us gets the nonzero error code
-                Console.Error.WriteLine(ex);
                 return -1;
             }
         }

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -31,10 +31,9 @@ namespace Squirrel.Update
             try {
                 return pg.main(args);
             } catch (Exception ex) {
-                ensureConsole();
-                Console.Error.WriteLine(ex);
                 // NB: Normally this is a terrible idea but we want to make
                 // sure Setup.exe above us gets the nonzero error code
+                Console.Error.WriteLine(ex);
                 return -1;
             }
         }
@@ -335,6 +334,8 @@ namespace Squirrel.Update
 
         public void Releasify(string package, string targetDir = null, string packagesDir = null, string bootstrapperExe = null, string backgroundGif = null, string signingOpts = null, string baseUrl = null, string setupIcon = null, bool generateMsi = true)
         {
+            ensureConsole();
+
             if (baseUrl != null) {
                 if (!Utility.IsHttpUrl(baseUrl)) {
                     throw new Exception(string.Format("Invalid --baseUrl '{0}'. A base URL must start with http or https and be a valid URI.", baseUrl));


### PR DESCRIPTION
When an exception is raised by Program.main, Program.Main will attempt to write it out to the console before returning with the exit code of -1.

However, if the console has not yet been allocated, then the user cannot see the error. This pull request ensures that the console has been allocated before the exception is written out to the console.