### PR TITLE
fix issue where SyncReleases wouldn't work with TLS1.2

### DIFF
--- a/src/SyncReleases/SyncImplementations.cs
+++ b/src/SyncReleases/SyncImplementations.cs
@@ -12,6 +12,11 @@ namespace SyncReleases
 {
     internal class SyncImplementations
     {
+        static SyncImplementations()
+        {
+            System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+        }
+
         public static async Task SyncRemoteReleases(Uri targetUri, DirectoryInfo releasesDir)
         {
             var releasesUri = Utility.AppendPathToUri(targetUri, "RELEASES");


### PR DESCRIPTION
This is the same issue that was fixed with https://github.com/Squirrel/Squirrel.Windows/commit/b464b41bb243380c5acad82f3336ff7c9b1e4cb3 but since SyncReleases does not use the WebClient object the fix did not apply.