### PR TITLE
Run from same folder

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -285,6 +285,7 @@ namespace Squirrel
             {
                 return Task.Run(async () => {
                     var target = getDirectoryForRelease(release.Version);
+                    var currentTemp = new DirectoryInfo(Path.Combine(rootAppDirectory, "currentTemp"));
 
                     // NB: This might happen if we got killed partially through applying the release
                     if (target.Exists) {
@@ -294,10 +295,22 @@ namespace Squirrel
 
                     target.Create();
 
+
+                    if (currentTemp.Exists)
+                    {
+                        this.Log().Warn("Found currentTemp folder, killing it: " + currentTemp.FullName);
+                        await Utility.DeleteDirectory(currentTemp.FullName);
+                    }
+
+                    currentTemp.Create();
+                
                     this.Log().Info("Writing files to app directory: {0}", target.FullName);
                     await ReleasePackage.ExtractZipForInstall(
                         Path.Combine(updateInfo.PackageDirectory, release.Filename),
                         target.FullName);
+                    await ReleasePackage.ExtractZipForInstall(
+                        Path.Combine(updateInfo.PackageDirectory, release.Filename),
+                        currentTemp.FullName);
 
                     return target.FullName;
                 });

--- a/src/StubExecutable/StubExecutable.cpp
+++ b/src/StubExecutable/StubExecutable.cpp
@@ -44,6 +44,17 @@ std::wstring FindLatestAppDir()
 {
 	std::wstring ourDir;
 	ourDir.assign(FindRootAppDir());
+	
+	//If current exists, just use that
+	std::wstring currDir;
+	currDir.assign(FindRootAppDir());
+	currDir += L"\\current";
+
+	WIN32_FIND_DATA currInfo = { 0 };
+	HANDLE currFile = FindFirstFile(currDir.c_str(), &currInfo);
+	if (currFile != INVALID_HANDLE_VALUE) {
+		return currDir.c_str();
+	}
 
 	ourDir += L"\\app-*";
 

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -542,7 +542,6 @@ namespace Squirrel.Update
                 var currentExe = RunFromCurrent(exeName, appDir);
                 if (currentExe != null)
                 {
-                    this.Log().Info("No current directory, falling back to latest app folder");
                     targetExe = currentExe;
                 }
                 this.Log().Info("About to launch: '{0}': {1}", targetExe.FullName, arguments ?? "");


### PR DESCRIPTION
This PR tries to solve #798 by always running the app from the same folder(named current).

After every update, the packages are extracted to a temp folder along with the new versioned folder. When update.exe restarts the application, it checks for this temp folder. If it exists, it copies to a folder named current and runs the application from current.
If for some reason, it cannot find current, it falls back to the finding the latest versioned folder.
The stub executable does the same and first checks for current before trying to find the latest folder.