### PR TITLE
fix verson parse exception on HandleEvents when SemVer(i.e. 1.0.1-rc)…

### DIFF
--- a/src/Squirrel/SquirrelAwareApp.cs
+++ b/src/Squirrel/SquirrelAwareApp.cs
@@ -64,7 +64,7 @@ namespace Squirrel
             if (args.Length != 2) return;
 
             if (!lookup.ContainsKey(args[0])) return;
-            var version = new Version(args[1]);
+            var version = args[1].ToSemanticVersion().Version;
 
             try {
                 lookup[args[0]](version);


### PR DESCRIPTION
SquirrelAwareApp.HandleEvents throws exception if used SemVer (i.e. 1.0.1-rc) since Version can't parse it