### PR TITLE
VS 2015 Code Analysis clean up

### DIFF
--- a/src/Setup/UpdateRunner.cpp
+++ b/src/Setup/UpdateRunner.cpp
@@ -172,7 +172,6 @@ int CUpdateRunner::ExtractUpdaterAndRun(wchar_t* lpCommandLine, bool useFallback
 	}
 
 	wchar_t username[512];
-	wchar_t uid[128];
 	wchar_t appDataDir[MAX_PATH];
 	ULONG unameSize = _countof(username);
 

--- a/src/Squirrel/BinaryPatchUtility.cs
+++ b/src/Squirrel/BinaryPatchUtility.cs
@@ -111,8 +111,7 @@ namespace Squirrel.Bsdiff
             int dblen = 0;
             int eblen = 0;
 
-            using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
-            using (BZip2OutputStream bz2Stream = new BZip2OutputStream(wrappingStream))
+            using (BZip2OutputStream bz2Stream = new BZip2OutputStream(new WrappingStream(output, Ownership.None)))
             {
                 // compute the differences, writing ctrl as we go
                 int scan = 0;
@@ -229,8 +228,7 @@ namespace Squirrel.Bsdiff
             WriteInt64(controlEndPosition - startPosition - c_headerSize, header, 8);
 
             // write compressed diff data
-            using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
-            using (BZip2OutputStream bz2Stream = new BZip2OutputStream(wrappingStream))
+            using (BZip2OutputStream bz2Stream = new BZip2OutputStream(new WrappingStream(output, Ownership.None)))
             {
                 bz2Stream.Write(db, 0, dblen);
             }
@@ -240,8 +238,7 @@ namespace Squirrel.Bsdiff
             WriteInt64(diffEndPosition - controlEndPosition, header, 16);
 
             // write compressed extra data
-            using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
-            using (BZip2OutputStream bz2Stream = new BZip2OutputStream(wrappingStream))
+            using (BZip2OutputStream bz2Stream = new BZip2OutputStream(new WrappingStream(output, Ownership.None)))
             {
                 bz2Stream.Write(eb, 0, eblen);
             }

--- a/src/Squirrel/IUpdateManager.cs
+++ b/src/Squirrel/IUpdateManager.cs
@@ -160,7 +160,7 @@ namespace Squirrel
                 await This.ErrorIfThrows(() => 
                     This.CreateUninstallerRegistryEntry(),
                     "Failed to set up uninstaller");
-            } catch (Exception ex) {
+            } catch {
                 if (ignoreDeltaUpdates == false) {
                     ignoreDeltaUpdates = true;
                     goto retry;

--- a/src/Squirrel/NativeMethods.cs
+++ b/src/Squirrel/NativeMethods.cs
@@ -35,7 +35,7 @@ namespace Squirrel
         [DllImport("version.dll", SetLastError = true)]
         [return:MarshalAs(UnmanagedType.Bool)] internal static extern bool GetFileVersionInfo(
             string lpszFileName, 
-            IntPtr dwHandleIgnored,
+            int dwHandleIgnored,
             int dwLen, 
             [MarshalAs(UnmanagedType.LPArray)] byte[] lpData);
 

--- a/src/Squirrel/NativeMethods.cs
+++ b/src/Squirrel/NativeMethods.cs
@@ -33,70 +33,70 @@ namespace Squirrel
 
 
         [DllImport("version.dll", SetLastError = true)]
-        [return:MarshalAs(UnmanagedType.Bool)] public static extern bool GetFileVersionInfo(
+        [return:MarshalAs(UnmanagedType.Bool)] internal static extern bool GetFileVersionInfo(
             string lpszFileName, 
             IntPtr dwHandleIgnored,
             int dwLen, 
             [MarshalAs(UnmanagedType.LPArray)] byte[] lpData);
 
         [DllImport("version.dll", SetLastError = true)]
-        public static extern int GetFileVersionInfoSize(
+        internal static extern int GetFileVersionInfoSize(
             string lpszFileName,
             IntPtr dwHandleIgnored);
 
         [DllImport("version.dll")]
-        [return:MarshalAs(UnmanagedType.Bool)] public static extern bool VerQueryValue(
+        [return:MarshalAs(UnmanagedType.Bool)] internal static extern bool VerQueryValue(
             byte[] pBlock, 
             string pSubBlock, 
             out IntPtr pValue, 
             out int len);
 
         [DllImport("psapi.dll", SetLastError=true)]
-        public static extern bool EnumProcesses(
+        internal static extern bool EnumProcesses(
             IntPtr pProcessIds, // pointer to allocated DWORD array
             int cb,
             out int pBytesReturned);
 
         [DllImport("kernel32.dll", SetLastError=true)]
-        public static extern bool QueryFullProcessImageName(
+        internal static extern bool QueryFullProcessImageName(
             IntPtr hProcess, 
             [In] int justPassZeroHere,
             [Out] StringBuilder lpImageFileName, 
             [In] [MarshalAs(UnmanagedType.U4)] ref int nSize);
 
         [DllImport("kernel32.dll", SetLastError=true)]
-        public static extern IntPtr OpenProcess(
+        internal static extern IntPtr OpenProcess(
             ProcessAccess processAccess,
             bool bInheritHandle,
             int processId);
 
         [DllImport("kernel32.dll", SetLastError = true)]
-        public static extern bool CloseHandle(IntPtr hHandle);
+        internal static extern bool CloseHandle(IntPtr hHandle);
 
         [DllImport("NTDLL.DLL", SetLastError=true)]
-        public static extern int NtQueryInformationProcess(IntPtr hProcess, PROCESSINFOCLASS pic, ref PROCESS_BASIC_INFORMATION pbi, int cb, out int pSize);
+        internal static extern int NtQueryInformationProcess(IntPtr hProcess, PROCESSINFOCLASS pic, ref PROCESS_BASIC_INFORMATION pbi, int cb, out int pSize);
 
         [DllImport("kernel32.dll", SetLastError=true)]
-        public static extern UInt32 WaitForSingleObject(IntPtr hHandle, UInt32 dwMilliseconds);
+        internal static extern UInt32 WaitForSingleObject(IntPtr hHandle, UInt32 dwMilliseconds);
 
         [DllImport("kernel32.dll", EntryPoint = "GetStdHandle")]
-        public static extern IntPtr GetStdHandle(StandardHandles nStdHandle);
+        internal static extern IntPtr GetStdHandle(StandardHandles nStdHandle);
 
         [DllImport("kernel32.dll", EntryPoint = "AllocConsole")]
-        [return: MarshalAs(UnmanagedType.Bool)] 
-        public static extern bool AllocConsole();
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool AllocConsole();
  
         [DllImport("kernel32.dll")]
-        public static extern bool AttachConsole(int pid);
+        internal static extern bool AttachConsole(int pid);
 
         [DllImport("Kernel32.dll", SetLastError=true)]
-        public static extern IntPtr BeginUpdateResource(string pFileName, bool bDeleteExistingResources);
+        internal static extern IntPtr BeginUpdateResource(string pFileName, bool bDeleteExistingResources);
 
         [DllImport("Kernel32.dll", SetLastError=true)]
-        public static extern bool UpdateResource(IntPtr handle, string pType, IntPtr pName, short language, [MarshalAs(UnmanagedType.LPArray)] byte[] pData, int dwSize);
+        internal static extern bool UpdateResource(IntPtr handle, string pType, IntPtr pName, short language, [MarshalAs(UnmanagedType.LPArray)] byte[] pData, int dwSize);
 
         [DllImport("Kernel32.dll", SetLastError=true)]
-        public static extern bool EndUpdateResource(IntPtr handle, bool discard);
+        internal static extern bool EndUpdateResource(IntPtr handle, bool discard);
     }
 
     [Flags]

--- a/src/Squirrel/ShellFile.cs
+++ b/src/Squirrel/ShellFile.cs
@@ -1047,7 +1047,7 @@ namespace Squirrel.Shell
             int dwLanguageId,
             string lpBuffer,
             uint nSize,
-            int argumentsLong);
+            IntPtr argumentsLong);
 
         [DllImport("kernel32")]
         static extern int GetLastError();
@@ -1158,7 +1158,7 @@ namespace Squirrel.Shell
                 string txtS = new string('\0', 256);
                 int len = FormatMessage(
                     FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                    IntPtr.Zero, err, 0, txtS, 256, 0);
+                    IntPtr.Zero, err, 0, txtS, 256, IntPtr.Zero);
                 Console.WriteLine("Len {0} text {1}", len, txtS);
 
                 // throw exception

--- a/src/Squirrel/ShellFile.cs
+++ b/src/Squirrel/ShellFile.cs
@@ -1021,7 +1021,7 @@ namespace Squirrel.Shell
         }
 
         [DllImport("shell32")]
-        static extern int SHGetFileInfo(
+        static extern IntPtr SHGetFileInfo(
             string pszPath,
             int dwFileAttributes,
             ref SHFILEINFO psfi,
@@ -1138,9 +1138,9 @@ namespace Squirrel.Shell
             SHFILEINFO shfi = new SHFILEINFO();
             uint shfiSize = (uint)Marshal.SizeOf(shfi.GetType());
 
-            int ret = SHGetFileInfo(
+            IntPtr ret = SHGetFileInfo(
                 fileName, 0, ref shfi, shfiSize, (uint)(flags));
-            if (ret != 0)
+            if (ret != IntPtr.Zero)
             {
                 if (shfi.hIcon != IntPtr.Zero)
                 {

--- a/src/Squirrel/SquirrelAwareExecutableDetector.cs
+++ b/src/Squirrel/SquirrelAwareExecutableDetector.cs
@@ -67,7 +67,7 @@ namespace Squirrel
             if (size <= 0 || size > 4096) return null;
 
             var buf = new byte[size];
-            if (!NativeMethods.GetFileVersionInfo(executable, IntPtr.Zero, size, buf)) return null;
+            if (!NativeMethods.GetFileVersionInfo(executable, 0, size, buf)) return null;
 
             IntPtr result; int resultSize;
             if (!NativeMethods.VerQueryValue(buf, "\\StringFileInfo\\040904B0\\SquirrelAwareVersion", out result, out resultSize)) {

--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -462,7 +462,7 @@ namespace Squirrel
         {
             try {
                 await Utility.DeleteDirectory(dir);
-            } catch (Exception ex) {
+            } catch {
                 var message = String.Format("Uninstall failed to delete dir '{0}'", dir);
             }
         }


### PR DESCRIPTION
This is a series of small changes suggested by the Code Analysis feature of VS 2015. Three of them fix bugs having to do with P/Invoke functions.