### PR TITLE
Raise additional progression events (when download is completed and when update is started)

### DIFF
--- a/src/Squirrel/FileDownloader.cs
+++ b/src/Squirrel/FileDownloader.cs
@@ -39,7 +39,13 @@ namespace Squirrel
                 try {
                     this.Log().Info("Downloading file: " + (failedUrl ?? url));
 
-                    await this.WarnIfThrows(() => wc.DownloadFileTaskAsync(failedUrl ?? url, targetFile),
+                    await this.WarnIfThrows(
+                     async () =>
+                        {
+                          await wc.DownloadFileTaskAsync(failedUrl ?? url, targetFile);
+                          progress(100);
+                        }
+                      ,
                         "Failed downloading URL: " + (failedUrl ?? url));
                 } catch (Exception) {
                     // NB: Some super brain-dead services are case-sensitive yet 

--- a/src/Squirrel/FileDownloader.cs
+++ b/src/Squirrel/FileDownloader.cs
@@ -40,12 +40,10 @@ namespace Squirrel
                     this.Log().Info("Downloading file: " + (failedUrl ?? url));
 
                     await this.WarnIfThrows(
-                     async () =>
-                        {
-                          await wc.DownloadFileTaskAsync(failedUrl ?? url, targetFile);
-                          progress(100);
-                        }
-                      ,
+                        async () => {
+                            await wc.DownloadFileTaskAsync(failedUrl ?? url, targetFile);
+                            progress(100);
+                        },
                         "Failed downloading URL: " + (failedUrl ?? url));
                 } catch (Exception) {
                     // NB: Some super brain-dead services are case-sensitive yet 

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -33,6 +33,7 @@ namespace Squirrel
             {
                 progress = progress ?? (_ => { });
 
+                progress(0);
                 var release = await createFullPackagesFromDeltas(updateInfo.ReleasesToApply, updateInfo.CurrentlyInstalledVersion);
                 progress(10);
 


### PR DESCRIPTION
Add some manual raises when download step is completed and when update step is started.

- Raise a 100% progression when download is completed
- Raise a 0% progression when ApplReleases is started

