### PR TITLE
Stop downloading remote updates that are lower than the current version

### DIFF
--- a/src/Squirrel/UpdateInfo.cs
+++ b/src/Squirrel/UpdateInfo.cs
@@ -63,7 +63,7 @@ namespace Squirrel
                 return new UpdateInfo(null, new[] { latestFull }, packageDirectory);
             }
 
-            if (currentVersion.Version == latestFull.Version) {
+            if (currentVersion.Version >= latestFull.Version) {
                 return new UpdateInfo(currentVersion, Enumerable.Empty<ReleaseEntry>(), packageDirectory);
             }
 


### PR DESCRIPTION
If the current version is not present on the update server then currently it will download the latest available (which is older), unpack it, and then after an app restart clean up by deleting it. This change makes sure old updates are not considered thus simply skipping the update process. This is needed for running the newly built versions (for testing purposes) which haven't been uploaded to the update server yet.