### PR TITLE
Add SharpCompress dependency to nuspec

### DIFF
--- a/src/Squirrel.nuspec
+++ b/src/Squirrel.nuspec
@@ -12,6 +12,7 @@
       <dependency id="DeltaCompressionDotNet" version="[1.0,2.0)" />
       <dependency id="Splat" version="1.6.2" />
       <dependency id="Mono.Cecil" version="0.9.6.1" />
+      <dependency id="SharpCompress" version="0.16.1" />
     </dependencies>
 
     <id>squirrel.windows</id>


### PR DESCRIPTION
I'm assuming that #1048 is a bug and that this will fix it. If not, reject away.

Fixes #1048.