### PR TITLE
Only generate execution stubs for the top-level executables

### DIFF
--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -573,6 +573,16 @@ namespace Squirrel
             return peExtensions.Any(x => ext.Equals(x, StringComparison.OrdinalIgnoreCase));
         }
 
+        public static bool IsFileTopLevelInPackage(string fullName, string pkgPath)
+        {
+            var fn = fullName.ToLowerInvariant();
+            var pkg = pkgPath.ToLowerInvariant();
+            var relativePath = fn.Replace(pkg, "");
+
+            // NB: We want to match things like `/lib/net45/foo.exe` but not `/lib/net45/bar/foo.exe`
+            return relativePath.Split(Path.DirectorySeparatorChar).Length == 4;
+        }
+
         public static void LogIfThrows(this IFullLogger This, LogLevel level, string message, Action block)
         {
             try {

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -406,7 +406,7 @@ namespace Squirrel.Update
 
                             this.Log().Info("About to sign {0}", x.FullName);
                             await signPEFile(x.FullName, signingOpts);
-                        })
+                        }, 1)
                         .Wait();
                 });
 

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -389,6 +389,7 @@ namespace Squirrel.Update
                     new DirectoryInfo(pkgPath).GetAllFilesRecursively()
                         .Where(x => x.Name.ToLowerInvariant().EndsWith(".exe"))
                         .Where(x => !x.Name.ToLowerInvariant().Contains("squirrel.exe"))
+                        .Where(x => Utility.IsFileTopLevelInPackage(x.FullName, pkgPath))
                         .Where(x => Utility.ExecutableUsesWin32Subsystem(x.FullName))
                         .ForEachAsync(x => createExecutableStubForExe(x.FullName))
                         .Wait();

--- a/test/UtilityTests.cs
+++ b/test/UtilityTests.cs
@@ -142,6 +142,18 @@ namespace Squirrel.Tests.Core
             Assert.Equal(result, Utility.FileIsLikelyPEImage(input));
         }
 
+        [Theory]
+        [InlineData("C:\\Users\\bob\\temp\\pkgPath\\lib\\net45\\foo.exe", "C:\\Users\\bob\\temp\\pkgPath", true)]
+        [InlineData("C:\\Users\\bob\\temp\\pkgPath\\lib\\net45\\node_modules\\foo.exe", "C:\\Users\\bob\\temp\\pkgPath", false)]
+        [InlineData("C:\\Users\\bob\\temp\\pkgPath\\lib\\net45\\node_modules\\foo\\foo.exe", "C:\\Users\\bob\\temp\\pkgPath", false)]
+        [InlineData("foo.png", "C:\\Users\\bob\\temp\\pkgPath", false)]
+        public void IsFileTopLevelInPackageTest(string input, string packagePath, bool result)
+        {
+            Assert.Equal(result, Utility.IsFileTopLevelInPackage(input, packagePath));
+        }
+
+
+
         [Fact]
         public void WeCanFetchAllProcesses()
         {


### PR DESCRIPTION
This PR makes it so we don't generate execution stubs for subfolder files, which is Usually Unwanted:tm: