### PR TITLE
Updated the documentation for Visual Studio Build Packaging

### DIFF
--- a/docs/using/visual-studio-packaging.md
+++ b/docs/using/visual-studio-packaging.md
@@ -15,7 +15,7 @@ The first step is to define a build target in your `.csproj` file.
     <Output TaskParameter="Assemblies" ItemName="myAssemblyInfo"/>
   </GetAssemblyIdentity>
   <Exec Command="nuget pack MyApp.nuspec -Version %(myAssemblyInfo.Version) -Properties Configuration=Release -OutputDirectory $(OutDir) -BasePath $(OutDir)" />
-  <Exec Command="squirrel --releasify $(OutDir)MyApp.%(myAssemblyInfo.Version).nupkg" />
+  <Exec Command="squirrel --releasify $(OutDir)MyApp.$([System.Version]::Parse(%(myAssemblyInfo.Version)).ToString(3)).nupkg" />
 </Target>
 ```
 


### PR DESCRIPTION
Minor change to the code example for passing the version to squirrel. Before it would pass the full version i.e. 1.0.0.0.

Since squirrel v1.5.0 this is not valid as it enforces SemVer. 

This fix was taken from #630.