### PR TITLE
Fixing null ref exception in log

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -511,12 +511,16 @@ namespace Squirrel
                         baseKey = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, view);
                         regKey = baseKey.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
 
-                        var toDelete = regKey.GetValueNames()
-                            .Where(x => x.StartsWith(rootAppDirectory, StringComparison.OrdinalIgnoreCase))
-                            .ToList();
+                        if (regKey != null)
+                        {
+                            var toDelete = regKey.GetValueNames()
+                                .Where(x => x.StartsWith(rootAppDirectory, StringComparison.OrdinalIgnoreCase))
+                                .ToList();
 
-                        toDelete.ForEach(x =>
-                            this.Log().LogIfThrows(LogLevel.Warn, "Failed to delete key: " + x, () => regKey.DeleteValue(x)));
+                            toDelete.ForEach(x =>
+                                this.Log().LogIfThrows(LogLevel.Warn, "Failed to delete key: " + x,
+                                    () => regKey.DeleteValue(x)));
+                        }
                     } catch (Exception e) {
                         this.Log().WarnException("Couldn't rewrite shim RegKey, most likely no apps are shimmed", e);
                     } finally {


### PR DESCRIPTION
Example error in log file
```
2017-07-03 15:03:04> ApplyReleasesImpl: Couldn't rewrite shim RegKey, most likely no apps are shimmed: System.NullReferenceException: Object reference not set to an instance of an object.
   at Squirrel.UpdateManager.ApplyReleasesImpl.<unshimOurselves>b__13_0(RegistryView view)
2017-07-03 15:03:04> ApplyReleasesImpl: Couldn't rewrite shim RegKey, most likely no apps are shimmed: System.NullReferenceException: Object reference not set to an instance of an object.
   at Squirrel.UpdateManager.ApplyReleasesImpl.<unshimOurselves>b__13_0(RegistryView view)
```

This is being caused because HKCU\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers does not exist. 
Since the `unshimOurselves()` is just looking to remove sub keys from it, it seems that this error condition should be checked and handled rather than throwing the null reference exception and logging the error.

This change checks for the null case and ignores it rather than logging a null reference exception.

System Information (clean install)
OS Name: Microsoft Windows 10 Enterprise N
Version: 10.0.15063 Build 15063

Squirrel.Windows NuGet version: 1.7.6 
