### PR TITLE
Validate update package signature

### DIFF
--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -65,6 +65,14 @@ namespace Squirrel
             await downloadReleases.DownloadReleases(updateUrlOrPath, releasesToDownload, progress, urlDownloader);
         }
 
+        public async Task VerifyReleases(IEnumerable<ReleaseEntry> releasesToDownload, bool verifySignature = false)
+        {
+            var downloadReleases = new DownloadReleasesImpl(rootAppDirectory);
+            await acquireUpdateLock();
+
+            await downloadReleases.VerifyReleases(releasesToDownload, verifySignature);
+        }
+
         public async Task<string> ApplyReleases(UpdateInfo updateInfo, Action<int> progress = null)
         {
             var applyReleases = new ApplyReleasesImpl(rootAppDirectory);


### PR DESCRIPTION
I've added an option to validate the packages before applying the update.
If signature verification is requested, it will continue with update only if the update package is signed and the Subject property of the certificate matches the one from the current executable.
If current app is not signed, it will skip the validation check even if user requests signature validation.

This fix was needed to restrict app updates to only trusted sources.