### PR TITLE
Readme: Recursive clone instead of submodules init

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ See the documentation [Table of Contents](docs/readme.md) for an overview of the
 For the impatient:
 
 ```sh
-git clone https://github.com/squirrel/squirrel.windows
+git clone --recursive https://github.com/squirrel/squirrel.windows
 cd squirrel.windows
-git submodule update --init --recursive       ## THIS IS THE PART YOU PROBABLY FORGOT
 .\.NuGet\NuGet.exe restore
 msbuild /p:Configuration=Release
 ```


### PR DESCRIPTION
The --[recursive](https://git-scm.com/docs/git-clone#git-clone---recurse-submodulesltpathspec) option when cloning is the equivalent of doing a `git submodule update --init --recursive`.