### PR TITLE
Skip net modal dialog

### DIFF
--- a/src/Setup/FxHelper.cpp
+++ b/src/Setup/FxHelper.cpp
@@ -5,6 +5,12 @@
 // http://msdn.microsoft.com/en-us/library/hh925568(v=vs.110).aspx#net_b
 static const wchar_t* ndpPath = L"SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full";
 static const int fx45ReleaseVersion = 378389;
+static const int fx451ReleaseVersion = 378675; //Minimum version for .NET 4.5.1
+static const int fx452ReleaseVersion = 379893;
+static const int fx46ReleaseVersion = 393295; //Windows 10 version, other systems are higher
+static const int fx461ReleaseVersion = 394254; // Minimum version for .NET 4.6.1
+static const int fx462ReleaseVersion = 394802; // Minimum version for .NET 4.6.2
+static const int fx47ReleaseVersion = 460798; // Minimum version for .NET 4.7
 
 // According to https://msdn.microsoft.com/en-us/library/8z6watww%28v=vs.110%29.aspx,
 // to install .NET 4.5 we must be Vista SP2+, Windows 7 SP1+, or later.
@@ -14,7 +20,22 @@ bool CFxHelper::CanInstallDotNet4_5()
 	return IsWindowsVistaOrGreater();
 }
 
-bool CFxHelper::IsDotNet45OrHigherInstalled()
+NetVersion CFxHelper::GetRequiredDotNetVersion()
+{
+	wchar_t* versionFlag = (wchar_t*)LoadResource(NULL, FindResource(NULL, (LPCWSTR)IDR_FX_VERSION_FLAG, L"FLAGS"));
+	CString resourceFlag(versionFlag);
+	if (resourceFlag.Compare(L"net451") == 0) return NetVersion::net451;
+	if (resourceFlag.Compare(L"net452") == 0) return NetVersion::net452;
+	if (resourceFlag.Compare(L"net46") == 0) return NetVersion::net46;
+	if (resourceFlag.Compare(L"net461") == 0) return NetVersion::net461;
+	if (resourceFlag.Compare(L"net462") == 0) return NetVersion::net462;
+	if (resourceFlag.Compare(L"net47") == 0) return NetVersion::net47;
+
+	//Default to standard net45
+	return NetVersion::net45;
+}
+
+bool CFxHelper::IsDotNetInstalled(NetVersion required)
 {
 	ATL::CRegKey key;
 
@@ -24,11 +45,32 @@ bool CFxHelper::IsDotNet45OrHigherInstalled()
 
 	DWORD dwReleaseInfo = 0;
 	if (key.QueryDWORDValue(L"Release", dwReleaseInfo) != ERROR_SUCCESS ||
-			dwReleaseInfo < fx45ReleaseVersion) {
+		dwReleaseInfo < GetDotNetVersionReleaseNumber(required)) {
 		return false;
 	}
 
 	return true;
+}
+
+int CFxHelper::GetDotNetVersionReleaseNumber(NetVersion version)
+{
+	switch (version) {
+	case NetVersion::net451:
+		return fx451ReleaseVersion;
+	case NetVersion::net452:
+		return fx452ReleaseVersion;
+	case NetVersion::net46:
+		return fx46ReleaseVersion;
+	case NetVersion::net461:
+		return fx461ReleaseVersion;
+	case NetVersion::net462:
+		return fx462ReleaseVersion;
+	case NetVersion::net47:
+		return fx47ReleaseVersion;
+	case NetVersion::net45:
+	default:
+		return fx45ReleaseVersion;
+	}
 }
 
 class ATL_NO_VTABLE CDownloadProgressCallback :
@@ -43,7 +85,7 @@ public:
 	DECLARE_NOT_AGGREGATABLE(CDownloadProgressCallback)
 
 	BEGIN_COM_MAP(CDownloadProgressCallback)
-	COM_INTERFACE_ENTRY(IBindStatusCallback)
+		COM_INTERFACE_ENTRY(IBindStatusCallback)
 	END_COM_MAP()
 
 	DECLARE_PROTECT_FINAL_CONSTRUCT()
@@ -84,40 +126,37 @@ private:
 	CComPtr<IProgressDialog> m_spProgressDialog;
 };
 
-HRESULT CFxHelper::InstallDotNetFramework(bool isQuiet)
+HRESULT CFxHelper::InstallDotNetFramework(NetVersion version, bool isQuiet)
 {
-	/*isQuiet = true;
 	if (!isQuiet) {
 		CTaskDialog dlg;
-		TASKDIALOG_BUTTON buttons [] = {
+		TASKDIALOG_BUTTON buttons[] = {
 			{ 1, L"Install", },
 			{ 2, L"Cancel", },
 		};
 
+
 		dlg.SetButtons(buttons, 2);
-		dlg.SetMainInstructionText(L"Install .NET 4.5");
-		dlg.SetContentText(L"This application requires the .NET Framework 4.5. Click the Install button to get started.");
+		dlg.SetMainInstructionText(GetInstallerMainInstructionForVersion(version));
+		dlg.SetContentText(GetInstallerContentForVersion(version));
 		dlg.SetMainIcon(TD_INFORMATION_ICON);
 
-		dlg.SetExpandedInformationText(
-				L"This application requires .NET Framework 4.5 or above. Clicking "
-				L"the Install button will download the latest version of this operating "
-				L"system component from Microsoft and install it on your PC.");
+		dlg.SetExpandedInformationText(GetInstallerExpandedInfoForVersion(version));
 
 		int nButton;
 		if (FAILED(dlg.DoModal(::GetActiveWindow(), &nButton)) || nButton != 1) {
 			return S_FALSE;
 		}
-	}*/
+	}
 
 	HRESULT hr = E_FAIL;
 	WCHAR szFinalTempFileName[_MAX_PATH] = L"";
 	CComPtr<IBindStatusCallback> bscb;
 	CComPtr<IProgressDialog> pd;
-	SHELLEXECUTEINFO execInfo = {sizeof(execInfo),};
+	SHELLEXECUTEINFO execInfo = { sizeof(execInfo), };
 
 	CString url;
-	url.LoadString(IDS_FXDOWNLOADURL);
+	url.LoadString(GetInstallerUrlForVersion(version));
 
 	WCHAR szTempPath[_MAX_PATH];
 	DWORD dwTempPathResult = GetTempPath(_MAX_PATH, szTempPath);
@@ -190,7 +229,8 @@ HRESULT CFxHelper::InstallDotNetFramework(bool isQuiet)
 
 	if (isQuiet) {
 		execInfo.lpParameters = L"/q /norestart";
-	} else {
+	}
+	else {
 		execInfo.lpParameters = L"/passive /norestart /showrmui";
 	}
 
@@ -213,7 +253,8 @@ HRESULT CFxHelper::InstallDotNetFramework(bool isQuiet)
 		// See https://msdn.microsoft.com/en-us/library/ee942965%28v=vs.110%29.aspx
 		hr = HandleRebootRequirement(isQuiet);
 		// Exit as a failure, so that setup doesn't carry on now
-	} else {
+	}
+	else {
 		hr = exitCode != 0 ? E_FAIL : S_OK;
 	}
 
@@ -230,6 +271,54 @@ out:
 	return hr;
 }
 
+UINT CFxHelper::GetInstallerMainInstructionForVersion(NetVersion version)
+{
+	if (version >= NetVersion::net47) {
+		return IDS_FXINSTRUCTION47;
+	}
+
+	if (version >= NetVersion::net46) {
+		return IDS_FXINSTRUCTION46;
+	}
+	return IDS_FXINSTRUCTION;
+}
+
+UINT CFxHelper::GetInstallerContentForVersion(NetVersion version)
+{
+	if (version >= NetVersion::net47) {
+		return IDS_FXCONTENT47;
+	}
+
+	if (version >= NetVersion::net46) {
+		return IDS_FXCONTENT46;
+	}
+	return IDS_FXCONTENT;
+}
+
+UINT CFxHelper::GetInstallerExpandedInfoForVersion(NetVersion version)
+{
+	if (version >= NetVersion::net47) {
+		return IDS_FXEXPANDEDINFO47;
+	}
+
+	if (version >= NetVersion::net46) {
+		return IDS_FXEXPANDEDINFO46;
+	}
+	return IDS_FXEXPANDEDINFO;
+}
+
+UINT CFxHelper::GetInstallerUrlForVersion(NetVersion version)
+{
+	if (version >= NetVersion::net47) {
+		return IDS_FXDOWNLOADURL47;
+	}
+
+	if (version >= NetVersion::net46) {
+		return IDS_FXDOWNLOADURL46;
+	}
+	return IDS_FXDOWNLOADURL;
+}
+
 // Deal with the aftermath of the framework installer telling us that we need to reboot
 HRESULT CFxHelper::HandleRebootRequirement(bool isQuiet)
 {
@@ -237,8 +326,8 @@ HRESULT CFxHelper::HandleRebootRequirement(bool isQuiet)
 		// Don't silently reboot - just error-out
 		fprintf_s(stderr, "A reboot is required following .NET installation - reboot then run installer again.\n");
 		return E_FAIL;
-	} 
-	
+	}
+
 	CTaskDialog dlg;
 	TASKDIALOG_BUTTON buttons[] = {
 		{ 1, L"Restart Now", },
@@ -247,7 +336,7 @@ HRESULT CFxHelper::HandleRebootRequirement(bool isQuiet)
 
 	dlg.SetButtons(buttons, 2);
 	dlg.SetMainInstructionText(L"Restart System");
-	dlg.SetContentText(L"To finish installing the .NET Framework 4.5, the system now needs to restart.  The installation will finish after you restart and log-in again.");
+	dlg.SetContentText(L"To finish installing the .NET Framework, the system now needs to restart.  The installation will finish after you restart and log-in again.");
 	dlg.SetMainIcon(TD_INFORMATION_ICON);
 
 	dlg.SetExpandedInformationText(L"If you click 'Cancel', you'll need to re-run this setup program yourself, after restarting your system.");
@@ -292,39 +381,6 @@ bool CFxHelper::WriteRunOnceEntry()
 
 	return true;
 }
-
-bool CFxHelper::WriteMeetingIdIntoRegistry()
-{
-	try
-	{
-
-		ATL::CRegKey key;
-
-		if (key.Open(HKEY_CURRENT_USER, L"SOFTWARE\\Classes\\veevaengage", KEY_WRITE) != ERROR_SUCCESS) {
-			if (key.Create(HKEY_CURRENT_USER, L"SOFTWARE\\Classes\\veevaengage") != ERROR_SUCCESS)
-			{
-				return false;
-			}
-		}
-
-		CString meetingId;
-		meetingId.LoadString(IDS_MEETINGID);
-
-		if (key.SetStringValue(L"FirstRunMeetingId", meetingId) != ERROR_SUCCESS) {
-			return false;
-		}
-
-	}
-	catch (int e)
-	{
-		
-		return false;
-	}
-
-	return true;
-}
-
-
 
 bool CFxHelper::RebootSystem()
 {

--- a/src/Setup/FxHelper.cpp
+++ b/src/Setup/FxHelper.cpp
@@ -126,9 +126,9 @@ private:
 	CComPtr<IProgressDialog> m_spProgressDialog;
 };
 
-HRESULT CFxHelper::InstallDotNetFramework(NetVersion version, bool isQuiet)
+HRESULT CFxHelper::InstallDotNetFramework(NetVersion version, bool isQuiet,bool skipNetModalDialog)
 {
-	if (!isQuiet) {
+	if (!isQuiet && !skipNetModalDialog) {
 		CTaskDialog dlg;
 		TASKDIALOG_BUTTON buttons[] = {
 			{ 1, L"Install", },

--- a/src/Setup/FxHelper.h
+++ b/src/Setup/FxHelper.h
@@ -1,15 +1,22 @@
 #pragma once
 
+enum class NetVersion {net45=0, net451=1, net452=2, net46=3, net461=4, net462=5, net47=6};
+
 class CFxHelper
 {
 public:
+	static NetVersion GetRequiredDotNetVersion();
 	static bool CanInstallDotNet4_5();
-	static bool IsDotNet45OrHigherInstalled();
-	static HRESULT InstallDotNetFramework(bool isQuiet);
-	static bool WriteMeetingIdIntoRegistry();
+	static bool IsDotNetInstalled(NetVersion requiredVersion);
+	static HRESULT InstallDotNetFramework(NetVersion version, bool isQuiet);
 private:
 	static HRESULT HandleRebootRequirement(bool isQuiet);
 	static bool WriteRunOnceEntry();
 	static bool RebootSystem();
+	static int GetDotNetVersionReleaseNumber(NetVersion version);
+	static UINT GetInstallerUrlForVersion(NetVersion version);
+	static UINT GetInstallerMainInstructionForVersion(NetVersion version);
+	static UINT GetInstallerContentForVersion(NetVersion version);
+	static UINT GetInstallerExpandedInfoForVersion(NetVersion version);
 };
 

--- a/src/Setup/FxHelper.h
+++ b/src/Setup/FxHelper.h
@@ -1,22 +1,15 @@
 #pragma once
 
-enum class NetVersion {net45=0, net451=1, net452=2, net46=3, net461=4, net462=5, net47=6};
-
 class CFxHelper
 {
 public:
-	static NetVersion GetRequiredDotNetVersion();
 	static bool CanInstallDotNet4_5();
-	static bool IsDotNetInstalled(NetVersion requiredVersion);
-	static HRESULT InstallDotNetFramework(NetVersion version, bool isQuiet);
+	static bool IsDotNet45OrHigherInstalled();
+	static HRESULT InstallDotNetFramework(bool isQuiet);
+	static bool WriteMeetingIdIntoRegistry();
 private:
 	static HRESULT HandleRebootRequirement(bool isQuiet);
 	static bool WriteRunOnceEntry();
 	static bool RebootSystem();
-	static int GetDotNetVersionReleaseNumber(NetVersion version);
-	static UINT GetInstallerUrlForVersion(NetVersion version);
-	static UINT GetInstallerMainInstructionForVersion(NetVersion version);
-	static UINT GetInstallerContentForVersion(NetVersion version);
-	static UINT GetInstallerExpandedInfoForVersion(NetVersion version);
 };
 

--- a/src/Setup/FxHelper.h
+++ b/src/Setup/FxHelper.h
@@ -8,7 +8,7 @@ public:
 	static NetVersion GetRequiredDotNetVersion();
 	static bool CanInstallDotNet4_5();
 	static bool IsDotNetInstalled(NetVersion requiredVersion);
-	static HRESULT InstallDotNetFramework(NetVersion version, bool isQuiet);
+	static HRESULT InstallDotNetFramework(NetVersion version, bool isQuiet,bool skipNetModalDialog);
 private:
 	static HRESULT HandleRebootRequirement(bool isQuiet);
 	static bool WriteRunOnceEntry();

--- a/src/Setup/winmain.cpp
+++ b/src/Setup/winmain.cpp
@@ -37,8 +37,6 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		wcscat(lpCmdLine, L" --silent");
 	}
 
-	CFxHelper::WriteMeetingIdIntoRegistry();
-
 	HRESULT hr = ::CoInitialize(NULL);
 	ATLASSERT(SUCCEEDED(hr));
 
@@ -63,12 +61,13 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		goto out;
 	}
 
+	NetVersion requiredVersion = CFxHelper::GetRequiredDotNetVersion();
 
-	if (!CFxHelper::IsDotNet45OrHigherInstalled()) {
-		hr = CFxHelper::InstallDotNetFramework(isQuiet);
+	if (!CFxHelper::IsDotNetInstalled(requiredVersion)) {
+		hr = CFxHelper::InstallDotNetFramework(requiredVersion, isQuiet);
 		if (FAILED(hr)) {
 			exitCode = hr; // #yolo
-			CUpdateRunner::DisplayErrorMessage(CString(L"Failed to install the .NET Framework, try installing .NET 4.5 or higher manually"), NULL);
+			CUpdateRunner::DisplayErrorMessage(CString(L"Failed to install the .NET Framework, try installing the latest version manually"), NULL);
 			goto out;
 		}
 	
@@ -91,9 +90,6 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		exitCode = 0;
 		goto out;
 	}
-
-
-
 
 	exitCode = CUpdateRunner::ExtractUpdaterAndRun(lpCmdLine, false);
 

--- a/src/Setup/winmain.cpp
+++ b/src/Setup/winmain.cpp
@@ -37,6 +37,8 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		wcscat(lpCmdLine, L" --silent");
 	}
 
+	CFxHelper::WriteMeetingIdIntoRegistry();
+
 	HRESULT hr = ::CoInitialize(NULL);
 	ATLASSERT(SUCCEEDED(hr));
 
@@ -61,13 +63,12 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		goto out;
 	}
 
-	NetVersion requiredVersion = CFxHelper::GetRequiredDotNetVersion();
 
-	if (!CFxHelper::IsDotNetInstalled(requiredVersion)) {
-		hr = CFxHelper::InstallDotNetFramework(requiredVersion, isQuiet);
+	if (!CFxHelper::IsDotNet45OrHigherInstalled()) {
+		hr = CFxHelper::InstallDotNetFramework(isQuiet);
 		if (FAILED(hr)) {
 			exitCode = hr; // #yolo
-			CUpdateRunner::DisplayErrorMessage(CString(L"Failed to install the .NET Framework, try installing the latest version manually"), NULL);
+			CUpdateRunner::DisplayErrorMessage(CString(L"Failed to install the .NET Framework, try installing .NET 4.5 or higher manually"), NULL);
 			goto out;
 		}
 	
@@ -90,6 +91,9 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		exitCode = 0;
 		goto out;
 	}
+
+
+
 
 	exitCode = CUpdateRunner::ExtractUpdaterAndRun(lpCmdLine, false);
 

--- a/src/Setup/winmain.cpp
+++ b/src/Setup/winmain.cpp
@@ -46,6 +46,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 
 	bool isQuiet = (cmdLine.Find(L"-s") >= 0);
 	bool weAreUACElevated = CUpdateRunner::AreWeUACElevated() == S_OK;
+	bool skipNetModalDialog = (cmdLine.Find(L"--skipNetModalDialog") >= 0);
 	bool attemptingToRerun = (cmdLine.Find(L"--rerunningWithoutUAC") >= 0);
 
 	if (weAreUACElevated && attemptingToRerun) {
@@ -64,7 +65,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 	NetVersion requiredVersion = CFxHelper::GetRequiredDotNetVersion();
 
 	if (!CFxHelper::IsDotNetInstalled(requiredVersion)) {
-		hr = CFxHelper::InstallDotNetFramework(requiredVersion, isQuiet);
+		hr = CFxHelper::InstallDotNetFramework(requiredVersion, isQuiet,skipNetModalDialog);
 		if (FAILED(hr)) {
 			exitCode = hr; // #yolo
 			CUpdateRunner::DisplayErrorMessage(CString(L"Failed to install the .NET Framework, try installing the latest version manually"), NULL);


### PR DESCRIPTION
I added --skipNetModalDialog parameter for Setup.exe as alternative for -s (quite) mode.

When user run setup.exe, we don't want to ask any dialog but we want to show .net framework installation progress.  If we use -s parameter, Setup.exe won't ask dialog but won't show any progress. It will install silently.