### PR TITLE
set the already sepcified icon to AnimatedGifWindow, too

### DIFF
--- a/src/Update/AnimatedGifWindow.cs
+++ b/src/Update/AnimatedGifWindow.cs
@@ -21,8 +21,9 @@ namespace Squirrel.Update
             var img = new Image();
             var src = default(BitmapImage);
 
+            var executionLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var source = Path.Combine(
-                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                executionLocation,
                 "background.gif");
 
             if (File.Exists(source)) {
@@ -35,6 +36,11 @@ namespace Squirrel.Update
                 this.Content = img;
                 this.Width = src.Width;
                 this.Height = src.Height;
+            }
+
+            var setupIcon = Path.Combine(executionLocation, "setupIcon.ico");
+            if (File.Exists(setupIcon)) {
+                Icon = BitmapFrame.Create(new Uri(setupIcon, UriKind.Relative));
             }
                         
             this.AllowsTransparency = true;

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -443,7 +443,7 @@ namespace Squirrel.Update
             var newestFullRelease = releaseEntries.MaxBy(x => x.Version).Where(x => !x.IsDelta).First();
 
             File.Copy(bootstrapperExe, targetSetupExe, true);
-            var zipPath = createSetupEmbeddedZip(Path.Combine(di.FullName, newestFullRelease.Filename), di.FullName, backgroundGif, signingOpts).Result;
+            var zipPath = createSetupEmbeddedZip(Path.Combine(di.FullName, newestFullRelease.Filename), di.FullName, backgroundGif, signingOpts, setupIcon).Result;
 
             var writeZipToSetup = Utility.FindHelperExecutable("WriteZipToSetup.exe");
 
@@ -581,7 +581,7 @@ namespace Squirrel.Update
             }
         }
 
-        async Task<string> createSetupEmbeddedZip(string fullPackage, string releasesDir, string backgroundGif, string signingOpts)
+        async Task<string> createSetupEmbeddedZip(string fullPackage, string releasesDir, string backgroundGif, string signingOpts, string setupIcon)
         {
             string tempPath;
 
@@ -596,6 +596,12 @@ namespace Squirrel.Update
                     this.ErrorIfThrows(() => {
                         File.Copy(backgroundGif, Path.Combine(tempPath, "background.gif"));
                     }, "Failed to write animated GIF to temp dir: " + tempPath);
+                }
+
+                if (!String.IsNullOrWhiteSpace(setupIcon)) {
+                    this.ErrorIfThrows(() => {
+                        File.Copy(setupIcon, Path.Combine(tempPath, "setupIcon.ico"));
+                    }, "Failed to write icon to temp dir: " + tempPath);
                 }
 
                 var releases = new[] { ReleaseEntry.GenerateFromFile(fullPackage) };


### PR DESCRIPTION
The icon, specified during releasify is not visible at all in the task bar, while installing. The default icon is visible. Attempting to fix https://github.com/Squirrel/Squirrel.Windows/issues/1146

![image](https://user-images.githubusercontent.com/1934067/35442659-5337cffc-02a8-11e8-8bad-cfaf4a23bc3e.png)

This PR aims to fix it by bundling the icon file, just like the loading gif and setting the `AnimatedGifWindow`'s Icon property.