### PR TITLE
Added Customizing option for setup.exe bootstrapper

### DIFF
--- a/src/Setup/Setup.vcxproj
+++ b/src/Setup/Setup.vcxproj
@@ -83,7 +83,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;secur32.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;secur32.lib;version.lib</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>compat.manifest</AdditionalManifestFiles>
@@ -109,7 +109,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;secur32.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;secur32.lib;version.lib</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>compat.manifest</AdditionalManifestFiles>
@@ -137,7 +137,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;secur32.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;secur32.lib;version.lib</AdditionalDependencies>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>compat.manifest</AdditionalManifestFiles>

--- a/src/Setup/UpdateRunner.h
+++ b/src/Setup/UpdateRunner.h
@@ -1,7 +1,6 @@
 #pragma once
 class CUpdateRunner
 {
-
 public:
 	static void DisplayErrorMessage(CString& errorMessage, wchar_t* logFile);
 	static HRESULT AreWeUACElevated();
@@ -9,4 +8,7 @@ public:
 	static bool DirectoryExists(wchar_t* szPath);
 	static bool DirectoryIsWritable(wchar_t* szPath);
 	static int ExtractUpdaterAndRun(wchar_t* lpCommandLine, bool useFallbackDir);
+
+protected:
+	static void CheckSpecialBuild(wchar_t* targetDir, wchar_t* commandLine);
 };


### PR DESCRIPTION
We are trying to use Squirrel as the Deployment solution for a SaaS based application. In order to connect to the right database or service we need a very small but important configuration switch in the application, a tenant key. I was looking for ways to inject this configuration without having to call --releasify multiple times, because there could be hundreds of possible target environments.

So what we are trying to do now, is to customize the installer on the fly when it is downloaded from our website. I'm doing this by temporarily copying the setup exe, calling rcedit.exe --set-version-string "SpecialBuild" "MyTenantKey" and resigning it. Also for larger automated deployments we allowed to pass this SpecialBuild argument as a commandline parameter for the setup.exe.
so setting the special build attribute with rcedit and applying --special-build "MyTenantKey" as a commandline argument form setup.exe has the same effect. 

When sucha specialbuild argument is passed i set an Environment Variable SQUIRREL_SPECIAL_BUILD and within my OnInitialIntall handler i can access this Information an store it in the UserConfig.

For now i'm using the --bootstrapperExe as a switch for squirrel.exe --releasify and pass my custom setup.exe, but because other people are also asking for a way to pass information through the initial setup to the app and because it doesn't change the existing behavior of your bootstrapper you might want to merge my changes to your project. 

Might solve #487 as well.