### PR TITLE
Synchronous code signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,4 +181,3 @@ tests/Test.xml
 ## CPP db crap
 *.db
 *.opendb
-/.vs/Squirrel/v15

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 ## Eclipse
 #################
 
+vendor/nuget*
+.vs/*
 *.pydevproject
 .project
 .metadata

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@
 ## Eclipse
 #################
 
-vendor/nuget*
-.vs/*
 *.pydevproject
 .project
 .metadata
@@ -183,3 +181,4 @@ tests/Test.xml
 ## CPP db crap
 *.db
 *.opendb
+/.vs/Squirrel/v15

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -344,6 +344,7 @@ namespace Squirrel.Update
 
         public void Releasify(string package, string targetDir = null, string packagesDir = null, string bootstrapperExe = null, string backgroundGif = null, string signingOpts = null, string baseUrl = null, string setupIcon = null, bool generateMsi = true, string frameworkVersion = null, bool generateDeltas = true)
         {
+            this.Log().Info("This is a custom version of Squirrel's Update.exe for Plays.tv");
             ensureConsole();
 
             if (baseUrl != null) {
@@ -404,16 +405,16 @@ namespace Squirrel.Update
 
                     new DirectoryInfo(pkgPath).GetAllFilesRecursively()
                         .Where(x => Utility.FileIsLikelyPEImage(x.Name))
-                        .ForEachAsync(async x => {
-                            if (isPEFileSigned(x.FullName)) {
+                        .ForEach(x => {
+                            if (isPEFileSigned(x.FullName))
+                            {
                                 this.Log().Info("{0} is already signed, skipping", x.FullName);
                                 return;
                             }
 
                             this.Log().Info("About to sign {0}", x.FullName);
-                            await signPEFile(x.FullName, signingOpts);
-                        }, 1)
-                        .Wait();
+                            signPEFile(x.FullName, signingOpts).Wait();
+                        });
                 });
 
                 processed.Add(rp.ReleasePackageFile);

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -344,7 +344,6 @@ namespace Squirrel.Update
 
         public void Releasify(string package, string targetDir = null, string packagesDir = null, string bootstrapperExe = null, string backgroundGif = null, string signingOpts = null, string baseUrl = null, string setupIcon = null, bool generateMsi = true, string frameworkVersion = null, bool generateDeltas = true)
         {
-            this.Log().Info("This is a custom version of Squirrel's Update.exe for Plays.tv");
             ensureConsole();
 
             if (baseUrl != null) {


### PR DESCRIPTION
Switching the Releasify method to code sign files in a synchronous method (as opposed to async). For larger projects, with more than 130 signable files, the async handling of this causes lots of deadlocks and freezes in our docker build image.

This simplified, synchronous version works awesome, has no freezes or deadlocks, and in our testing (with lots of signable files) actually completes faster than the previous async version. Go figure. =)