### PR TITLE
Strong passwords (anything except [a-zA-Z0-9_]) are now being obfuscated correctly for signtool calls

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -641,7 +641,7 @@ namespace Squirrel.Update
                 String.Format("sign {0} \"{1}\"", signingOpts, exePath), CancellationToken.None);
 
             if (processResult.Item1 != 0) {
-                var optsWithPasswordHidden = new Regex(@"/p\s+\w+").Replace(signingOpts, "/p ********");
+                var optsWithPasswordHidden = new Regex(@"/p\s+\S+").Replace(signingOpts, "/p ********");
                 var msg = String.Format("Failed to sign, command invoked was: '{0} sign {1} {2}'",
                     exe, optsWithPasswordHidden, exePath);
 


### PR DESCRIPTION
Currently passwords when using signtool.exe are obfuscated using an Regex with \w+ which is only "word characters".

What we actually want is any "non whitespace character", which is \S+.

This is beeing fixed by this PR.