### PR TITLE
Don't extract the release package file twice.

### DIFF
--- a/src/Squirrel/DeltaPackage.cs
+++ b/src/Squirrel/DeltaPackage.cs
@@ -69,9 +69,6 @@ namespace Squirrel
                     basePackage.ReleasePackageFile, newPackage.ReleasePackageFile, tempPath);
 
                 Utility.ExtractZipToDirectory(basePackage.ReleasePackageFile, baseTempInfo.FullName).Wait();
-                var opts = new ExtractionOptions() { ExtractFullPath = true, Overwrite = true, PreserveFileTime = true };
-
-                Utility.ExtractZipToDirectory(basePackage.ReleasePackageFile, baseTempInfo.FullName).Wait();
                 Utility.ExtractZipToDirectory(newPackage.ReleasePackageFile, tempInfo.FullName).Wait();
 
                 // Collect a list of relative paths under 'lib' and map them


### PR DESCRIPTION
This fix speeds up the delta package process.