### PR TITLE
Fixed grouping of app icons in Windows Taskbar when creating shortcuts.

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -163,7 +163,7 @@ namespace Squirrel
                     if (!locations.HasFlag(f)) continue;
 
                     var file = linkTargetForVersionInfo(f, zf, fileVerInfo);
-                    var appUserModelId = String.Format("com.squirrel.{0}.{1}", zf.Id.Replace(" ", ""), exeName.Replace(".exe", "").Replace(" ", ""));
+                    var appUserModelId = String.Format("com.squirrel.{0}.{1}", zf.Id.Replace(" ", ""), Path.GetFileNameWithoutExtension(exeName).Replace(" ", ""));
                     var toastActivatorCLSDID = Utility.CreateGuidFromHash(appUserModelId).ToString();
 
                     this.Log().Info("Creating shortcut for {0} => {1}", exeName, file);
@@ -239,7 +239,7 @@ namespace Squirrel
                             sl.Arguments += String.Format(" -a \"{0}\"", programArguments);
                         }
 
-                        var appUserModelId = String.Format("com.squirrel.{0}.{1}", zf.Id.Replace(" ", ""), exeName.Replace(".exe", "").Replace(" ", ""));
+                        var appUserModelId = String.Format("com.squirrel.{0}.{1}", zf.Id.Replace(" ", ""), Path.GetFileNameWithoutExtension(exeName).Replace(" ", ""));
                         var toastActivatorCLSID = Utility.CreateGuidFromHash(appUserModelId).ToString();
 
                         sl.SetAppUserModelId(appUserModelId);


### PR DESCRIPTION
This change is for when using the --createShortcut option.
Changed the appUserModelId to not have the full path to the exe, instead just point out the application's name.
The same id should then be used at startup in your app using the Shell32.lib function SetCurrentProcessExplicitAppUserModelID, which will make the icons in the taskbar look like it's the same application.
Ex: SetCurrentProcessExplicitAppUserModelID("com.squirrel.[nuspec_id].[exe_name]");

By doing this the user can pin either the bootstrap or the actual application to the taskbar, and they will end up in the same group in the taskbar.