### PR TITLE
WIP: Update NuGet submodule and add test for double-digit prerelease sorting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "vendor/nuget"]
 	path = vendor/nuget
-	url = https://github.com/paulcbetts/NuGet
+	url = https://github.com/daviwil/NuGet
+	branch = fix-prerelease-comparison

--- a/test/ReleaseEntryTests.cs
+++ b/test/ReleaseEntryTests.cs
@@ -264,9 +264,10 @@ namespace Squirrel.Tests.Core
         }
 
         [Fact]
-        public void SortDoubleDigitPrereleaseVersionsCorrectly()
+        public void WhenPreReleasesAreOutOfOrderSortByNumericSuffix()
         {
             var path = Path.GetTempFileName();
+            var firstVersion = new SemanticVersion("1.1.9-beta105");
             var secondVersion = new SemanticVersion("1.2.0-beta9");
             var thirdVersion = new SemanticVersion("1.2.0-beta10");
             var fourthVersion = new SemanticVersion("1.2.0-beta100");
@@ -275,6 +276,7 @@ namespace Squirrel.Tests.Core
                 ReleaseEntry.ParseReleaseEntry(MockReleaseEntry("Espera-1.2.0-beta1-full.nupkg")),
                 ReleaseEntry.ParseReleaseEntry(MockReleaseEntry("Espera-1.2.0-beta9-full.nupkg")),
                 ReleaseEntry.ParseReleaseEntry(MockReleaseEntry("Espera-1.2.0-beta100-full.nupkg")),
+                ReleaseEntry.ParseReleaseEntry(MockReleaseEntry("Espera-1.1.9-beta105-full.nupkg")),
                 ReleaseEntry.ParseReleaseEntry(MockReleaseEntry("Espera-1.2.0-beta10-full.nupkg"))
             };
 
@@ -282,9 +284,10 @@ namespace Squirrel.Tests.Core
 
             var releases = ReleaseEntry.ParseReleaseFile(File.ReadAllText(path)).ToArray();
 
-            Assert.Equal(secondVersion, releases[1].Version);
-            Assert.Equal(thirdVersion, releases[2].Version);
-            Assert.Equal(fourthVersion, releases[3].Version);
+            Assert.Equal(firstVersion, releases[0].Version);
+            Assert.Equal(secondVersion, releases[2].Version);
+            Assert.Equal(thirdVersion, releases[3].Version);
+            Assert.Equal(fourthVersion, releases[4].Version);
         }
 
         [Fact]

--- a/test/ReleaseEntryTests.cs
+++ b/test/ReleaseEntryTests.cs
@@ -264,6 +264,30 @@ namespace Squirrel.Tests.Core
         }
 
         [Fact]
+        public void SortDoubleDigitPrereleaseVersionsCorrectly()
+        {
+            var path = Path.GetTempFileName();
+            var secondVersion = new SemanticVersion("1.2.0-beta9");
+            var thirdVersion = new SemanticVersion("1.2.0-beta10");
+            var fourthVersion = new SemanticVersion("1.2.0-beta100");
+
+            var releaseEntries = new[] {
+                ReleaseEntry.ParseReleaseEntry(MockReleaseEntry("Espera-1.2.0-beta1-full.nupkg")),
+                ReleaseEntry.ParseReleaseEntry(MockReleaseEntry("Espera-1.2.0-beta9-full.nupkg")),
+                ReleaseEntry.ParseReleaseEntry(MockReleaseEntry("Espera-1.2.0-beta100-full.nupkg")),
+                ReleaseEntry.ParseReleaseEntry(MockReleaseEntry("Espera-1.2.0-beta10-full.nupkg"))
+            };
+
+            ReleaseEntry.WriteReleaseFile(releaseEntries, path);
+
+            var releases = ReleaseEntry.ParseReleaseFile(File.ReadAllText(path)).ToArray();
+
+            Assert.Equal(secondVersion, releases[1].Version);
+            Assert.Equal(thirdVersion, releases[2].Version);
+            Assert.Equal(fourthVersion, releases[3].Version);
+        }
+
+        [Fact]
         public void StagingUsersGetBetaSoftware()
         {
             // NB: We're kind of using a hack here, in that we know that the 


### PR DESCRIPTION
This is a follow-up PR to https://github.com/paulcbetts/NuGet/pull/1 that updates this repo's `nuget` submodule to a commit which has the fix for double-digit prerelease version number comparisons as explained in that PR.  I've added a test to verify that the versions

**NOTE:** This PR is WIP until the aforementioned PR gets merged, I'll update the submodule to point to the right repo/commit at that time.