### PR TITLE
Add support to override default Codepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ tests/Test.xml
 ## CPP db crap
 *.db
 *.opendb
+.vs/

--- a/docs/using/nuget-package-metadata.md
+++ b/docs/using/nuget-package-metadata.md
@@ -5,14 +5,16 @@
 
 Squirrel uses information from your app's EXE as well as the NuGet package Metadata for the setup and uninstall UI.
 
-* **Id** - name of the application (**warning:** you must **[avoid using spaces and dots](https://github.com/Squirrel/Squirrel.Windows/issues/523)** in the Id). 
-   * Name of the release packages (e.g., **MyApp**-1.0.0-full.nupkg). 
-   * Local installation directory (e.g., `%LocalAppData%\MyApp`).
+* **Id** - name of the application (**warning:** you must **[avoid using spaces and dots](https://github.com/Squirrel/Squirrel.Windows/issues/523)** in the Id).
+  * Name of the release packages (e.g., **MyApp**-1.0.0-full.nupkg). 
+  * Local installation directory (e.g., `%LocalAppData%\MyApp`).
 * **Title** - used for the name of the application in the Windows Application Uninstaller.
 * **Version** - version specified in `Properties\Assembly.cs`. 
-   * Name of the release package (e.g., MyApp-**1.0.0**-full.nupkg).
-   * Version number in the Windows Uninstaller (see screenshot below).
-* **Icon Url** - url to an icon to be used for the application. Used for the shortcuts and Windows Uninstaller icons. This must be an icon file (*.ICO) to work correctly. Note that the icon is fetched at installation time rather than packaging (source: [issue #745](https://github.com/Squirrel/Squirrel.Windows/issues/745))
+  * Name of the release package (e.g., MyApp-**1.0.0**-full.nupkg).
+  * Version number in the Windows Uninstaller (see screenshot below).
+* **Icon Url** - url to an icon to be used for the application. Used for the shortcuts and Windows Uninstaller icons. This must be an icon file (*.ICO) to work correctly. Note that the icon is fetched at installation time rather than
+ packaging (source: [issue #745](https://github.com/Squirrel/Squirrel.Windows/issues/745))
+* **Language** Changes the codepage in to support non english characters. Defaults to 1252 if not present.
 
 ![](images/uninstall-app.png)
 

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -725,6 +726,9 @@ namespace Squirrel.Update
             var setupExeDir = Path.GetDirectoryName(setupExe);
             var company = String.Join(",", package.Authors);
 
+            var culture = CultureInfo.GetCultureInfo(package.Language ?? "").TextInfo.ANSICodePage;
+
+
             var templateText = File.ReadAllText(Path.Combine(pathToWix, "template.wxs"));
             var templateData = new Dictionary<string, string> {
                 { "Id", package.Id },
@@ -732,6 +736,7 @@ namespace Squirrel.Update
                 { "Author", company },
                 { "Version", Regex.Replace(package.Version.ToString(), @"-.*$", "") },
                 { "Summary", package.Summary ?? package.Description ?? package.Id },
+                { "Codepage", $"{culture}" }
             };
 
             // NB: We need some GUIDs that are based on the package ID, but unique (i.e.

--- a/vendor/wix/template.wxs
+++ b/vendor/wix/template.wxs
@@ -1,5 +1,5 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension">
-  <Product Id="*" Name="{{Title}} Machine-Wide Installer" Language="1033" Version="!(bind.FileVersion.{{Id}}.exe)" UpgradeCode="{{IdAsGuid1}}" Manufacturer="{{Author}}">
+  <Product Id="*" Name="{{Title}} Machine-Wide Installer" Language="1033" Codepage="{{Codepage}}" Version="!(bind.FileVersion.{{Id}}.exe)" UpgradeCode="{{IdAsGuid1}}" Manufacturer="{{Author}}">
 
     <Package Description="#Description" Comments="Comments" InstallerVersion="200" Compressed="yes"/>
 		<Media Id="1" Cabinet="contents.cab" EmbedCab="yes" CompressionLevel="high"/>


### PR DESCRIPTION
When using non-default characters (i.e. danish æ/ø/å) in the assembly the codepage in template.wxs needs to be set. The codepage is set depending on the language in the nuspec file, defaults to 1252.