### PR TITLE
Expose an $(SquirrelToolsPath) property for nuget consumers

### DIFF
--- a/src/Squirrel.nuspec
+++ b/src/Squirrel.nuspec
@@ -25,6 +25,7 @@
     <file src="Squirrel\bin\Release\Squirrel.*" target="lib\Net45" />
     <file src="Squirrel\bin\Release\NuGet.Squirrel.*" target="lib\Net45" />
     <file src="Squirrel\bin\Release\ICSharpCode.*" target="lib\Net45" />
+    <file src="Squirrel.props" target="build" />
     <file src="Setup\bin\Release\Setup.exe" target="tools" />
     <file src="WriteZipToSetup\bin\Release\WriteZipToSetup.exe" target="tools" />
     <file src="StubExecutable\bin\Release\StubExecutable.exe" target="tools" />

--- a/src/Squirrel.props
+++ b/src/Squirrel.props
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SquirrelToolsPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)..\tools'))</SquirrelToolsPath>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
When using the nuget package, it's often convenient to
be able to execute it in some targets. However, since the nuget
install path depends on the version of the package, it's typically
harder than necessary to figure out the path to tools.

This adds a .props file that is automatically imported by nuget
when installed in a project, therefore making it trivial to invoke
the tools by just using the new $(SquirrelToolsPath) MSBuild property
from anywhere in the project or its imported targets.

Since it's in a .props, it means that even downstream packages that
add a dependency on this package can leverage the tool too without
having to know what version of the Squirrel.Windows package is in use.

Fixes #1364