### PR TITLE
Added Staged-Percentage option

### DIFF
--- a/src/Squirrel/ReleaseEntry.cs
+++ b/src/Squirrel/ReleaseEntry.cs
@@ -74,6 +74,11 @@ namespace Squirrel
             }
         }
 
+        public void SetStagingPercentage(float stagingPercentage)
+        {
+            this.StagingPercentage = stagingPercentage;
+        }
+
         public string GetReleaseNotes(string packageDirectory)
         {
             var zp = new ZipPackage(Path.Combine(packageDirectory, Filename));


### PR DESCRIPTION
Adding an option to the cli fox specifying an initial staged percentage. Gives a fix to #1378 .
Note that it adds the percentage to all new releases, including delta releases (does it make sense?)
