### PR TITLE
Fix #1283 (Spaces in filename cause ReleaseEntry Regex to fail)

### DIFF
--- a/src/Squirrel/ReleaseEntry.cs
+++ b/src/Squirrel/ReleaseEntry.cs
@@ -92,7 +92,7 @@ namespace Squirrel
             return zp.IconUrl;
         }
 
-        static readonly Regex entryRegex = new Regex(@"^([0-9a-fA-F]{40})\s+(\S+)\s+(\d+)[\r]*$");
+        static readonly Regex entryRegex = new Regex(@"^([0-9a-fA-F]{40})\s+(\S[\S ]*?)\s+(\d+)[\r]*$");
         static readonly Regex commentRegex = new Regex(@"\s*#.*$");
         static readonly Regex stagingRegex = new Regex(@"#\s+(\d{1,3})%$");
         public static ReleaseEntry ParseReleaseEntry(string entry)


### PR DESCRIPTION
Regex change allows spaces in the filename for while requiring at least one non-space character to fix #1283. Worked with @JohnThomson to refined the regex in the issue comments.