### PR TITLE
Pass working directory as an argument during Process Start

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -549,8 +549,9 @@ namespace Squirrel.Update
             if (shouldWait) waitForParentToExit();
 
             try {
-                this.Log().Info("About to launch: '{0}': {1}", targetExe.FullName, arguments ?? "");
-                Process.Start(new ProcessStartInfo(targetExe.FullName, arguments ?? "") { WorkingDirectory = Path.GetDirectoryName(targetExe.FullName) });
+                arguments = string.IsNullOrEmpty(arguments) ? $"--squirrel-cwd=\"{Environment.CurrentDirectory}\"" : $"{arguments} --squirrel-cwd=\"{Environment.CurrentDirectory}\"";
+                this.Log().Info("About to launch: '{0}': {1}", targetExe.FullName, arguments);
+                Process.Start(new ProcessStartInfo(targetExe.FullName, arguments) { WorkingDirectory = Path.GetDirectoryName(targetExe.FullName) });
             } catch (Exception ex) {
                 this.Log().ErrorException("Failed to start process", ex);
             }


### PR DESCRIPTION
Pass working directory as --squirrel-cwd argument to targetExe during ProcessStart.

Fix for issue [#1047](https://github.com/Squirrel/Squirrel.Windows/issues/1407).
[commit 1438452](https://github.com/Squirrel/Squirrel.Windows/commit/14384528f66df822eadaaf340a3d1769468fe4f6) changes the default working directory to the targetExe folder, hence passing the default working directory as an argument.