### PR TITLE
fix bsdiff creation for patches that don't contain bsdiff extra data

### DIFF
--- a/src/Squirrel/BinaryPatchUtility.cs
+++ b/src/Squirrel/BinaryPatchUtility.cs
@@ -240,11 +240,14 @@ namespace Squirrel.Bsdiff
             long diffEndPosition = output.Position;
             WriteInt64(diffEndPosition - controlEndPosition, header, 16);
 
-            // write compressed extra data
-            using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
-            using (var bz2Stream = new BZip2Stream(wrappingStream, CompressionMode.Compress))
+            // write compressed extra data, if any
+            if (eblen > 0)
             {
-                bz2Stream.Write(eb, 0, eblen);
+                using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
+                using (var bz2Stream = new BZip2Stream(wrappingStream, CompressionMode.Compress))
+                {
+                    bz2Stream.Write(eb, 0, eblen);
+                }
             }
 
             // seek to the beginning, write the header, then seek back to end
@@ -326,10 +329,13 @@ namespace Squirrel.Bsdiff
                 compressedDiffStream.Seek(c_headerSize + controlLength, SeekOrigin.Current);
                 compressedExtraStream.Seek(c_headerSize + controlLength + diffLength, SeekOrigin.Current);
 
+                // the stream might end here if there is no extra data
+                var hasExtraData = compressedExtraStream.Position < compressedExtraStream.Length;
+
                 // decompress each part (to read it)
                 using (var controlStream = new BZip2Stream(compressedControlStream, CompressionMode.Decompress))
                 using (var diffStream = new BZip2Stream(compressedDiffStream, CompressionMode.Decompress))
-                using (var extraStream = new BZip2Stream(compressedExtraStream, CompressionMode.Decompress))
+                using (var extraStream = hasExtraData ? new BZip2Stream(compressedExtraStream, CompressionMode.Decompress) : null)
                 {
                     long[] control = new long[3];
                     byte[] buffer = new byte[8];

--- a/test/DeltaPackageTests.cs
+++ b/test/DeltaPackageTests.cs
@@ -290,5 +290,28 @@ namespace Squirrel.Tests.Core
                 tempFiles.ForEach(File.Delete);
             }
         }
+
+        [Fact]
+        public void HandleBsDiffWithoutExtraData()
+        {
+            var baseFileData = new byte[] { 1, 1, 1, 1 };
+            var newFileData = new byte[] { 2, 1, 1, 1 };
+
+            byte[] patchData;
+
+            using (var patchOut = new MemoryStream())
+            {
+                Bsdiff.BinaryPatchUtility.Create(baseFileData, newFileData, patchOut);
+                patchData = patchOut.ToArray();
+            }
+
+            using (var toPatch = new MemoryStream(baseFileData))
+            using (var patched = new MemoryStream())
+            {
+                Bsdiff.BinaryPatchUtility.Apply(toPatch, () => new MemoryStream(patchData), patched);
+
+                Assert.Equal(newFileData, patched.ToArray());
+            }
+        }
     }
 }


### PR DESCRIPTION
When a created bsdiff patch does not contain any extra data, a `System.DivideByZeroException` is thrown by SharpCompress when trying to compress the (zero-sized) extra data (as also reported in #1101 ).
This fix skips writing and reading the extra data if there is none in the patch.

For us, this was also the cause of electron/windows-installer#185.