### PR TITLE
Unzip to temporary folder

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -286,8 +286,8 @@ namespace Squirrel
                     var target = getDirectoryForRelease(release.Version);
 	                var temporaryTarget = new DirectoryInfo(target.FullName.Replace("app", "TEMP"));
 
-					// NB: This might happen if we got killed partially through applying the release
-					if (target.Exists) {
+                    // NB: This might happen if we got killed partially through applying the release
+                    if (target.Exists) {
                         this.Log().Warn("Found partially applied release folder, killing it: " + target.FullName);
                         await Utility.DeleteDirectory(target.FullName);
                     }
@@ -305,10 +305,10 @@ namespace Squirrel
                         temporaryTarget.FullName,
                         rootAppDirectory);
 
-	                this.Log().Info("Renaming temporary app directory: {0} to: {1}", temporaryTarget.FullName, target.FullName);
+                    this.Log().Info("Renaming temporary app directory: {0} to: {1}", temporaryTarget.FullName, target.FullName);
 	                temporaryTarget.MoveTo(target.FullName);
 
-					return target.FullName;
+                    return target.FullName;
                 });
             }
 

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -300,7 +300,7 @@ namespace Squirrel
 	                temporaryTarget.Create();
 
 	                this.Log().Info("Writing files to temporary app directory: {0}", temporaryTarget.FullName);
-					await ReleasePackage.ExtractZipForInstall(
+                    await ReleasePackage.ExtractZipForInstall(
                         Path.Combine(updateInfo.PackageDirectory, release.Filename),
                         temporaryTarget.FullName,
                         rootAppDirectory);


### PR DESCRIPTION
Unzip to temporary folder to avoid broken install if application crashes or is closed during unzipping stage of updating.

Relates to [issue #1427](https://github.com/Squirrel/Squirrel.Windows/issues/1427)