### PR TITLE
 Add Logging to Releasify

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -512,10 +512,8 @@ namespace Squirrel.Update
                 File.Delete(zipPath);
             }
 
-            // Alias parameter because cannot pass to anonymous lambda otherwise
-            var targetSetupExeAlias = targetSetupExe;
             Utility.Retry(() =>
-                setPEVersionInfoAndIcon(targetSetupExeAlias, new ZipPackage(package), setupIcon).Wait());
+                setPEVersionInfoAndIcon(targetSetupExe, new ZipPackage(package), setupIcon).Wait());
 
             if (signingOpts != null) {
                 signPEFile(targetSetupExe, signingOpts).Wait();

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -348,14 +348,14 @@ namespace Squirrel.Update
             try {
                 this.Log().Debug("Begin Releasify");
                 ensureConsole();
-                ReleasifyValidateBaseUrl(ref baseUrl);
-                ReleasifyValidatePaths(ref targetDir, ref packagesDir, ref bootstrapperExe);
-                ReleasifyPrepareFiles(package, targetDir, out var di, out var toProcess, out var processed, out var releaseFilePath, out var previousReleases);
-                ReleasifyProcessFiles(targetDir, packagesDir, signingOpts, generateDeltas, toProcess, di, processed, previousReleases);
-                ReleasifyCleanupFiles(toProcess);
-                ReleasifyWriteReleaseFile(baseUrl, processed, previousReleases, releaseFilePath, out var releaseEntries);
-                ReleasifyCreateSetupExe(package, bootstrapperExe, backgroundGif, signingOpts, setupIcon, frameworkVersion, di, releaseEntries, out var targetSetupExe);
-                ReleasifyGenerateMsi(package, signingOpts, generateMsi, targetSetupExe);
+                ValidateBaseUrl(ref baseUrl);
+                ValidatePaths(ref targetDir, ref packagesDir, ref bootstrapperExe);
+                PrepareFiles(package, targetDir, out var di, out var toProcess, out var processed, out var releaseFilePath, out var previousReleases);
+                ProcessFiles(targetDir, packagesDir, signingOpts, generateDeltas, toProcess, di, processed, previousReleases);
+                CleanupFiles(toProcess);
+                WriteReleaseFile(baseUrl, processed, previousReleases, releaseFilePath, out var releaseEntries);
+                CreateSetupExe(package, bootstrapperExe, backgroundGif, signingOpts, setupIcon, frameworkVersion, di, releaseEntries, out var targetSetupExe);
+                GenerateMsi(package, signingOpts, generateMsi, targetSetupExe);
                 this.Log().Debug("Completed Releasify");
             } catch (Exception ex) {
                 this.Log().Error(ex);
@@ -363,7 +363,7 @@ namespace Squirrel.Update
             }
         }
 
-        private void ReleasifyValidateBaseUrl(ref string baseUrl)
+        void ValidateBaseUrl(ref string baseUrl)
         {
             this.Log().Debug("Validating BaseUrl");
             if (baseUrl != null) {
@@ -377,7 +377,7 @@ namespace Squirrel.Update
             }
         }
 
-        private void ReleasifyValidatePaths(ref string targetDir, ref string packagesDir, ref string bootstrapperExe)
+        void ValidatePaths(ref string targetDir, ref string packagesDir, ref string bootstrapperExe)
         {
             this.Log().Debug("Validating Paths");
             targetDir = targetDir ?? Path.Combine(".", "Releases");
@@ -396,7 +396,7 @@ namespace Squirrel.Update
             this.Log().Info("Bootstrapper EXE found at:" + bootstrapperExe);
         }
 
-        private void ReleasifyPrepareFiles(string package, string targetDir, out DirectoryInfo di,
+        void PrepareFiles(string package, string targetDir, out DirectoryInfo di,
             out IEnumerable<FileInfo> toProcess, out List<string> processed, out string releaseFilePath, out List<ReleaseEntry> previousReleases)
         {
             this.Log().Debug("Preparing Files");
@@ -416,7 +416,7 @@ namespace Squirrel.Update
             }
         }
 
-        private void ReleasifyProcessFiles(string targetDir, string packagesDir, string signingOpts, bool generateDeltas,
+        void ProcessFiles(string targetDir, string packagesDir, string signingOpts, bool generateDeltas,
             IEnumerable<FileInfo> toProcess, DirectoryInfo di, List<string> processed, List<ReleaseEntry> previousReleases)
         {
             this.Log().Debug("Processing Files");
@@ -462,13 +462,13 @@ namespace Squirrel.Update
             }
         }
 
-        private void ReleasifyCleanupFiles(IEnumerable<FileInfo> toProcess)
+        void CleanupFiles(IEnumerable<FileInfo> toProcess)
         {
             this.Log().Debug("Cleaning Up Files");
             foreach (var file in toProcess) { File.Delete(file.FullName); }
         }
 
-        private void ReleasifyWriteReleaseFile(string baseUrl, List<string> processed, List<ReleaseEntry> previousReleases, string releaseFilePath,
+        void WriteReleaseFile(string baseUrl, List<string> processed, List<ReleaseEntry> previousReleases, string releaseFilePath,
             out List<ReleaseEntry> releaseEntries)
         {
             this.Log().Debug("Writing RELEASES file");
@@ -482,7 +482,7 @@ namespace Squirrel.Update
             ReleaseEntry.WriteReleaseFile(releaseEntries, releaseFilePath);
         }
 
-        private void ReleasifyCreateSetupExe(string package, string bootstrapperExe, string backgroundGif, string signingOpts,
+        void CreateSetupExe(string package, string bootstrapperExe, string backgroundGif, string signingOpts,
             string setupIcon, string frameworkVersion, DirectoryInfo di, List<ReleaseEntry> releaseEntries, out string targetSetupExe)
         {
             this.Log().Debug("Creating Setup.exe");
@@ -514,7 +514,7 @@ namespace Squirrel.Update
             }
         }
 
-        private void ReleasifyGenerateMsi(string package, string signingOpts, bool generateMsi, string targetSetupExe)
+        void GenerateMsi(string package, string signingOpts, bool generateMsi, string targetSetupExe)
         {
             if (generateMsi) {
                 this.Log().Debug("Generating .msi");

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -95,12 +95,12 @@ namespace Squirrel.Update
                 bool silentInstall = false;
                 var updateAction = default(UpdateAction);
 
-                string processStart = default(string);
-                bool shouldWait = false;
                 string releaseDir = default(string);
-                string icon = default(string);
+                string processStart = default(string);
                 string processStartArgs = default(string);
+                string icon = default(string);
                 string shortcutArgs = default(string);
+                bool shouldWait = false;
 
                 opts = new OptionSet() {
                     "Usage: Squirrel.exe command [OPTS]",

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -399,7 +399,6 @@ namespace Squirrel.Update
         }
 
         DirectoryInfo targetDirInfo;
-        string package;
         IEnumerable<FileInfo> toProcess;
         List<string> processed;
         string releaseFilePath;
@@ -408,7 +407,7 @@ namespace Squirrel.Update
         {
             this.Log().Debug("Preparing Files");
             targetDirInfo = new DirectoryInfo(targetDir);
-            File.Copy(package, Path.Combine(targetDirInfo.FullName, Path.GetFileName(package)), true);
+            File.Copy(target, Path.Combine(targetDirInfo.FullName, Path.GetFileName(target)), true);
 
             var allNuGetFiles = targetDirInfo.EnumerateFiles()
                 .Where(x => x.Name.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase));
@@ -511,7 +510,7 @@ namespace Squirrel.Update
             }
 
             Utility.Retry(() =>
-                setPEVersionInfoAndIcon(targetSetupExe, new ZipPackage(package), setupIcon).Wait());
+                setPEVersionInfoAndIcon(targetSetupExe, new ZipPackage(target), setupIcon).Wait());
 
             if (signingParameters != null) {
                 signPEFile(targetSetupExe, signingParameters).Wait();
@@ -522,7 +521,7 @@ namespace Squirrel.Update
         {
             if (!noMsi) {
                 this.Log().Debug("Generating .msi");
-                createMsiPackage(targetSetupExe, new ZipPackage(package)).Wait();
+                createMsiPackage(targetSetupExe, new ZipPackage(target)).Wait();
 
                 if (signingParameters != null) {
                     signPEFile(targetSetupExe.Replace(".exe", ".msi"), signingParameters).Wait();

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -58,11 +58,9 @@ namespace Squirrel.Update
         }
 
         string target = default(string);
-        string releaseDir = default(string);
         string packagesDir = default(string);
         string bootstrapperExe = default(string);
         string backgroundGif = default(string);
-        string signingParameters = default(string);
         string baseUrl = default(string);
         string setupIcon = default(string);
         string frameworkVersion = "net45";
@@ -97,10 +95,12 @@ namespace Squirrel.Update
                 var updateAction = default(UpdateAction);
 
                 string processStart = default(string);
-                string processStartArgs = default(string);
-                string icon = default(string);
-                string shortcutArgs = default(string);
                 bool shouldWait = false;
+                string releaseDir = default(string);
+                string icon = default(string);
+                string signingParameters = default(string);
+                string processStartArgs = default(string);
+                string shortcutArgs = default(string);
 
                 opts = new OptionSet() {
                     "Usage: Squirrel.exe command [OPTS]",
@@ -344,17 +344,6 @@ namespace Squirrel.Update
             }
         }
 
-        string package;
-        string signingOpts;
-        string targetDir;
-        DirectoryInfo targetDirInfo;
-        string targetSetupExe;
-        IEnumerable<FileInfo> toProcess;
-        List<string> processed;
-        string releaseFilePath;
-        List<ReleaseEntry> releaseEntries;
-        List<ReleaseEntry> previousReleases;
-
         public void Releasify()
         {
             try {
@@ -389,6 +378,7 @@ namespace Squirrel.Update
             }
         }
 
+        string targetDir;
         void ValidatePaths()
         {
             this.Log().Debug("Validating Paths");
@@ -408,6 +398,12 @@ namespace Squirrel.Update
             this.Log().Info("Bootstrapper EXE found at:" + bootstrapperExe);
         }
 
+        DirectoryInfo targetDirInfo;
+        string package;
+        IEnumerable<FileInfo> toProcess;
+        List<string> processed;
+        string releaseFilePath;
+        List<ReleaseEntry> previousReleases;
         void PrepareFiles()
         {
             this.Log().Debug("Preparing Files");
@@ -427,6 +423,7 @@ namespace Squirrel.Update
             }
         }
 
+        string signingOpts;
         void ProcessFiles()
         {
             this.Log().Debug("Processing Files");
@@ -478,6 +475,7 @@ namespace Squirrel.Update
             foreach (var file in toProcess) { File.Delete(file.FullName); }
         }
 
+        List<ReleaseEntry> releaseEntries;
         void WriteReleaseFile()
         {
             this.Log().Debug("Writing RELEASES file");
@@ -491,6 +489,7 @@ namespace Squirrel.Update
             ReleaseEntry.WriteReleaseFile(releaseEntries, releaseFilePath);
         }
 
+        string targetSetupExe;
         void CreateSetupExe()
         {
             this.Log().Debug("Creating Setup.exe");

--- a/src/Update/Update.csproj
+++ b/src/Update/Update.csproj
@@ -39,13 +39,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DeltaCompressionDotNet">
-      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net20\DeltaCompressionDotNet.dll</HintPath>
+      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net45\DeltaCompressionDotNet.dll</HintPath>
     </Reference>
     <Reference Include="DeltaCompressionDotNet.MsDelta">
-      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net20\DeltaCompressionDotNet.MsDelta.dll</HintPath>
+      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net45\DeltaCompressionDotNet.MsDelta.dll</HintPath>
     </Reference>
     <Reference Include="DeltaCompressionDotNet.PatchApi">
-      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net20\DeltaCompressionDotNet.PatchApi.dll</HintPath>
+      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net45\DeltaCompressionDotNet.PatchApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>


### PR DESCRIPTION
 # Add Logging to Releasify

The following refactor was brought about because we (Age Partnership) were running into difficulty using Squirrel in the Azure DevOps Build Pipelines and existing logging wasn't sufficient for our needs.

I don't expect any functionality to have changed.

The Releasify method in Update.exe has been broken up into;

* ensureConsole
* ValidateBaseUrl
* ValidatePaths
* PrepareFiles
* ProcessFiles
* CleanupFiles
* WriteReleaseFile
* CreateSetupExe
* GenerateMsi

Breaking Releasify up into smaller methods allows stack traces to be more useful when identifying issues.

The refactoring was done using ReSharper. Only significant change is the use of `out var` declarations and passing variables using `ref`. I expect a more significant refactor could make this cleaner.  Debug logs have been added to the start of each method and the whole Releasify method is now in a "try / catch / log / throw" block.