### PR TITLE
 Use AutoFlush = true in Logger for Update.exe

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -857,7 +857,7 @@ namespace Squirrel.Update
     class SetupLogLogger : Splat.ILogger, IDisposable
     {
         TextWriter inner;
-        readonly object gate = 42;
+        readonly object gate = new object();
         public Splat.LogLevel Level { get; set; }
 
         public SetupLogLogger(bool saveInTemp)
@@ -870,7 +870,7 @@ namespace Squirrel.Update
 
                     var file = Path.Combine(dir, String.Format("SquirrelSetup.{0}.log", i).Replace(".0.log", ".log"));
                     var str = File.Open(file, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
-                    inner = new StreamWriter(str, Encoding.UTF8, 4096, false);
+                    inner = new StreamWriter(str, Encoding.UTF8, 4096, false) { AutoFlush = true };
                     return;
                 } catch (Exception ex) {
                     // Didn't work? Keep going

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -857,7 +857,7 @@ namespace Squirrel.Update
     class SetupLogLogger : Splat.ILogger, IDisposable
     {
         TextWriter inner;
-        readonly object gate = new object();
+        readonly object gate = 42;
         public Splat.LogLevel Level { get; set; }
 
         public SetupLogLogger(bool saveInTemp)

--- a/src/Update/Update.csproj
+++ b/src/Update/Update.csproj
@@ -39,13 +39,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DeltaCompressionDotNet">
-      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net45\DeltaCompressionDotNet.dll</HintPath>
+      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net20\DeltaCompressionDotNet.dll</HintPath>
     </Reference>
     <Reference Include="DeltaCompressionDotNet.MsDelta">
-      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net45\DeltaCompressionDotNet.MsDelta.dll</HintPath>
+      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net20\DeltaCompressionDotNet.MsDelta.dll</HintPath>
     </Reference>
     <Reference Include="DeltaCompressionDotNet.PatchApi">
-      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net45\DeltaCompressionDotNet.PatchApi.dll</HintPath>
+      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net20\DeltaCompressionDotNet.PatchApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>

--- a/src/Update/Update.csproj
+++ b/src/Update/Update.csproj
@@ -39,13 +39,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DeltaCompressionDotNet">
-      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net20\DeltaCompressionDotNet.dll</HintPath>
+      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net45\DeltaCompressionDotNet.dll</HintPath>
     </Reference>
     <Reference Include="DeltaCompressionDotNet.MsDelta">
-      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net20\DeltaCompressionDotNet.MsDelta.dll</HintPath>
+      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net45\DeltaCompressionDotNet.MsDelta.dll</HintPath>
     </Reference>
     <Reference Include="DeltaCompressionDotNet.PatchApi">
-      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net20\DeltaCompressionDotNet.PatchApi.dll</HintPath>
+      <HintPath>..\..\packages\DeltaCompressionDotNet.1.1.0\lib\net45\DeltaCompressionDotNet.PatchApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>


### PR DESCRIPTION
# Use AutoFlush = true in Logger for Update.exe

Using AutoFlush = true allows;

* Logs to still be written in a catastrophic failure condition.
* User to watch the log in real time using something like `Get-Content -Wait`
or `tail -f`

From my testing and due to the nature of the operations conducted by Update.exe the performance impact of AutoFlush is negligible.