### PR TITLE
Allow for `app-0.0.0` to be correctly identified

### DIFF
--- a/src/StubExecutable/StubExecutable.cpp
+++ b/src/StubExecutable/StubExecutable.cpp
@@ -67,7 +67,7 @@ std::wstring FindLatestAppDir()
 
 		version::Semver200_version thisVer(s);
 
-		if (thisVer > acc) {
+		if (thisVer >= acc) {
 			acc = thisVer;
 			acc_s = appVer;
 		}

--- a/src/StubExecutable/StubExecutable.cpp
+++ b/src/StubExecutable/StubExecutable.cpp
@@ -53,7 +53,7 @@ std::wstring FindLatestAppDir()
 		return NULL;
 	}
 
-	version::Semver200_version acc("0.0.0");
+	version::Semver200_version acc("0.0.0-0");
 	std::wstring acc_s;
 
 	do {
@@ -67,13 +67,13 @@ std::wstring FindLatestAppDir()
 
 		version::Semver200_version thisVer(s);
 
-		if (thisVer >= acc) {
+		if (thisVer > acc) {
 			acc = thisVer;
 			acc_s = appVer;
 		}
 	} while (FindNextFile(hFile, &fileInfo));
 
-	if (acc == version::Semver200_version("0.0.0")) {
+	if (acc == version::Semver200_version("0.0.0-0")) {
 		return NULL;
 	}
 


### PR DESCRIPTION
For local builds of my app, we hard-code the version number to `0.0.0`.
After updating to the latest Squirrel, we found that even after installing, the app was no longer launchable.

This change ought to fix that behavior, and allow `app-0.0.0` to be launchable again.  And since all other filenames ought to be unique, it should have no other side effects.