### PR TITLE
Dll hijacking fix

### DIFF
--- a/src/Setup/Setup.vcxproj
+++ b/src/Setup/Setup.vcxproj
@@ -25,6 +25,7 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>Static</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -83,7 +84,8 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;secur32.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;urlmon.lib</AdditionalDependencies>
+      <DelayLoadDLLs>user32.dll;advapi32.dll;shell32.dll;ole32.dll;oleaut32.dll;urlmon.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>compat.manifest</AdditionalManifestFiles>
@@ -109,7 +111,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;secur32.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;urlmon.lib</AdditionalDependencies>
+      <DelayLoadDLLs>user32.dll;advapi32.dll;shell32.dll;ole32.dll;oleaut32.dll;urlmon.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>compat.manifest</AdditionalManifestFiles>
@@ -137,7 +140,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;urlmon.lib;secur32.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;urlmon.lib</AdditionalDependencies>
+      <DelayLoadDLLs>user32.dll;advapi32.dll;shell32.dll;ole32.dll;oleaut32.dll;urlmon.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>compat.manifest</AdditionalManifestFiles>

--- a/src/Setup/winmain.cpp
+++ b/src/Setup/winmain.cpp
@@ -7,16 +7,49 @@
 #include "UpdateRunner.h"
 #include "MachineInstaller.h"
 #include <cstdio>
+#include <string>
 
 CAppModule* _Module;
 
 typedef BOOL(WINAPI *SetDefaultDllDirectoriesFunction)(DWORD DirectoryFlags);
+
+// Some libraries are still loaded from the current directories.
+// If we pre-load them with an absolute path then we are good.
+void PreloadLibs()
+{
+	wchar_t sys32Folder[MAX_PATH];
+	GetSystemDirectory(sys32Folder, MAX_PATH);
+
+	std::wstring version = (std::wstring(sys32Folder) + L"\\version.dll");
+	std::wstring logoncli = (std::wstring(sys32Folder) + L"\\logoncli.dll");
+	std::wstring sspicli = (std::wstring(sys32Folder) + L"\\sspicli.dll");
+
+	LoadLibrary(version.c_str());
+	LoadLibrary(logoncli.c_str());
+	LoadLibrary(sspicli.c_str());
+}
+
+void MitigateDllHijacking()
+{
+	// Set the default DLL lookup directory to System32 for ourselves and kernel32.dll
+	SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32);
+
+	HMODULE hKernel32 = LoadLibrary(L"kernel32.dll");
+	ATLASSERT(hKernel32 != NULL);
+
+	SetDefaultDllDirectoriesFunction pfn = (SetDefaultDllDirectoriesFunction)GetProcAddress(hKernel32, "SetDefaultDllDirectories");
+	if (pfn) { (*pfn)(LOAD_LIBRARY_SEARCH_SYSTEM32); }
+
+	PreloadLibs();
+}
 
 int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
                       _In_opt_ HINSTANCE hPrevInstance,
                       _In_ LPWSTR lpCmdLine,
                       _In_ int nCmdShow)
 {
+	MitigateDllHijacking();
+
 	// Attempt to mitigate http://textslashplain.com/2015/12/18/dll-hijacking-just-wont-die
 	HMODULE hKernel32 = LoadLibrary(L"kernel32.dll");
 	ATLASSERT(hKernel32 != NULL);

--- a/src/Setup/winmain.cpp
+++ b/src/Setup/winmain.cpp
@@ -48,14 +48,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
                       _In_ LPWSTR lpCmdLine,
                       _In_ int nCmdShow)
 {
-	MitigateDllHijacking();
-
-	// Attempt to mitigate http://textslashplain.com/2015/12/18/dll-hijacking-just-wont-die
-	HMODULE hKernel32 = LoadLibrary(L"kernel32.dll");
-	ATLASSERT(hKernel32 != NULL);
-
-	SetDefaultDllDirectoriesFunction pfn = (SetDefaultDllDirectoriesFunction) GetProcAddress(hKernel32, "SetDefaultDllDirectories");
-	if (pfn) { (*pfn)(LOAD_LIBRARY_SEARCH_SYSTEM32); }
+	MitigateDllHijacking();	
 
 	int exitCode = -1;
 	CString cmdLine(lpCmdLine);


### PR DESCRIPTION
The current DLL hijacking prevention code in Squirrel isn't effective  enough. 

**How do we know**
So how do we know that we are vulnerable and which DLLs are a vector to attack? A simple look into ProcMon reveals the loading attempts of DLL from the local folder. Its best to set filter for the name of our executable, Paths that end with DLL and Results of NAME NOT FOUND.
![image](https://user-images.githubusercontent.com/5191943/52019884-1958d780-24a4-11e9-8ffc-6bcd1ec187fd.png)

In order to avoid the local DLL loading on all platforms and each code path I had to deploy all the following techniques.  😭 

**Static linking**
Enabling static linked reduced the number of local DLL loading already. However, this was not full enabled for our binary. While Multi-Threaded (/MT) was enabled we missed the Static Library setting for Use of MFC. Why do we need both. Because SO says so https://stackoverflow.com/questions/37398/how-do-i-make-a-fully-statically-linked-exe-with-visual-studio-express-2005  
Setting the default DLL directory
Squirrel already had an attempt to fix DLL hijacking. First code in Setup was this: 
```
HMODULE hKernel32 = LoadLibrary(L"kernel32.dll");
ATLASSERT(hKernel32 != NULL);

SetDefaultDllDirectoriesFunction pfn = (SetDefaultDllDirectoriesFunction) GetProcAddress(hKernel32, "SetDefaultDllDirectories");
if (pfn) { (*pfn)(LOAD_LIBRARY_SEARCH_SYSTEM32); }
```

Basically we telling the kernel32.dll to look first into the System32 folder. However, in my experimentations this had no effect. I also tried calling SetDefaultDllDirectories() directly on Setup.exe and other DLLs that get loaded. 

**Delayed DLL loading**
As mentioned in the previous paragraph SetDefaultDllDirectories() had no effect. The reason for this is that by default DLL are loaded at load-time of the module. So before any code runs we are already doomed. Luckily there is way to tell the linker to change this behavior to runtime loading via the /DelayLoad switch. This way DLLs will only be loaded if they are accessed. This gives us a chance to run code very early in the main function before any DDL is loaded and therefor SetDefaultDllDirectories() offers salvation.

**Preloading DLLs**
While the previous steps were good enough for Windows 10, we still see DLLs loaded from the current folder on Windows 7. Since we have delayed loading enabled we are in luck and can use some trickery. If we load the libraries in question with a full path to System32 before the actual code that needs them then we no new attempt is made to load them because they are already in memory. 
