### PR TITLE
update support, 64bit support, better naming

### DIFF
--- a/docs/using/squirrel-command-line.md
+++ b/docs/using/squirrel-command-line.md
@@ -23,6 +23,16 @@ Options:
                                installation
   -n, --signWithParams=VALUE Sign the installer via SignTool.exe with the
                                parameters given
+      --setupIcon=VALUE       Path to an ICO file that will be used for the 
+                               Setup executable's icon
+  -b  --baseUrl=VALUE         Provides a base URL to prefix the RELEASES file 
+                               packages with
+      --no-msi                Don't generate an MSI package
+      --msi-win64             Mark the MSI as 64-bit, which is useful in
+                               Enterprise deployment scenarios
+      --no-delta              Don't generate delta packages to save time
+      --framework-version=VALUE 
+                              Set the required .NET framework version, e.g. net461
 ```
 
 ## See Also

--- a/vendor/wix/template.wxs
+++ b/vendor/wix/template.wxs
@@ -1,8 +1,9 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension">
-  <Product Id="*" Name="{{Title}} Machine-Wide Installer" Language="1033" Codepage="{{Codepage}}" Version="!(bind.FileVersion.{{Id}}.exe)" UpgradeCode="{{IdAsGuid1}}" Manufacturer="{{Author}}">
+  <Product Id="*" Name="{{Title}} Deployment Tool" Language="1033" Codepage="{{Codepage}}" Version="!(bind.FileVersion.{{Id}}.exe)" UpgradeCode="{{IdAsGuid1}}" Manufacturer="{{Author}}">
 
-    <Package Description="#Description" Comments="Comments" InstallerVersion="200" Compressed="yes"/>
-		<Media Id="1" Cabinet="contents.cab" EmbedCab="yes" CompressionLevel="high"/>
+    <Package Description="This package installs a deployment tool for {{Title}}. Not {{Title}} itself. {{Title}} is only installed if a user logs into the machine." Comments="Comments" InstallerVersion="200" Compressed="yes" Platform="{{Platform}}"/>
+    <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A later version of this product is already installed. Setup will now exit."/>
+    <Media Id="1" Cabinet="contents.cab" EmbedCab="yes" CompressionLevel="high"/>
 
     <PropertyRef Id="NETFRAMEWORK45" />
 
@@ -11,21 +12,21 @@
     </Condition>
 
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="APPLICATIONROOTDIRECTORY" Name="{{Title}} Installer" />
+      <Directory Id="{{ProgramFilesFolder}}">
+        <Directory Id="APPLICATIONROOTDIRECTORY" Name="{{Title}} Deployment" />
       </Directory>
     </Directory>
 
     <DirectoryRef Id="APPLICATIONROOTDIRECTORY">
-      <Component Id="{{Id}}.exe" Guid="{{IdAsGuid2}}">
-        <File Id="{{Id}}.exe" Name="{{Id}}.exe" Source="./Setup.exe" KeyPath="yes" />
+      <Component Id="{{Id}}.exe" Guid="{{IdAsGuid2}}" Win64="{{Win64YesNo}}">
+        <File Id="{{Id}}.exe" Name="{{Id}}DeploymentTool.exe" Source="./Setup.exe" KeyPath="yes"/>
       </Component>
     </DirectoryRef>
 
     <DirectoryRef Id="TARGETDIR">
-      <Component Id="RegistryEntries" Guid="{{IdAsGuid3}}">
+      <Component Id="RegistryEntries" Guid="{{IdAsGuid3}}" Win64="{{Win64YesNo}}">
         <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Run">
-          <RegistryValue Type="expandable" Name="{{Id}}MachineInstaller" Value="%ProgramFiles%\{{Title}} Installer\{{Id}}.exe --checkInstall" />
+          <RegistryValue Type="expandable" Name="{{Id}}MachineInstaller" Value="%ProgramFiles%\{{Title}} Deployment\{{Id}}DeploymentTool.exe --checkInstall" />
         </RegistryKey>
       </Component>
     </DirectoryRef>


### PR DESCRIPTION
This PR brings several MSI improvements that were repeatedly requested by customers (IT administrators)

**Update Support**
The WIX template already accommodated a `<UpgradeCode/>` tag that is necessary uninstalling older versions of the MSI. However, to actually trigger an uninstall when installing a new one, it was missing the `<MajorUpgrade/>` tag. No more. Old version will be removed now.

**64bit Support**
When offering your App as 64-bit, administrators also expect the installer package to behave 64-bit. Meaning that the installer is puts things under `Program Files` not `Program Files (x86)` and registry keys are written under `HKLM\SOFTWARE\...` and not `HKLM\SOFTWARE\WOW6432Node\...`  A new optional parameter `-arch=VALUE` allows to define the architecture for the packaging process. While only the value `x64` will currently have an effect, it leaves the door open for future architecture differentiations.

**Better Naming**
Many customer struggle with the concept what the MSI in Squirrel is and what machine-wide installer in this context means. Naming the MSI `MyApp Machine-Wide installer` implies that actually MyApp gets installed machine-wide when in reality only an installer that installs MyApp gets installed. So this PR attempts to make it more clear what the MSI is and what it installs. The best way to describe it is an installer for a tool that helps deploy `MyApp` on per-user bases. Therefor the MSI will be listed as `MyApp Per-User Deployment`. Also the new folder naming should make it clear what gets installed. `C:\Program Files\MyApp Deployment\MyAppDeploymentTool.exe`

