### PR TITLE
Update Squirrel.nuspec

### DIFF
--- a/src/Squirrel.nuspec
+++ b/src/Squirrel.nuspec
@@ -10,7 +10,7 @@
 
     <dependencies>
       <dependency id="DeltaCompressionDotNet" version="[1.1,2.0)" />
-      <dependency id="Splat" version="1.6.2" />
+      <dependency id="Splat" version="[1.6.2,7.0)" />
       <dependency id="Mono.Cecil" version="0.9.6.1" />
       <dependency id="SharpCompress" version="[0.17.1]" />
     </dependencies>


### PR DESCRIPTION
Restricting splat version to prevent incompatibility.

Tested Squirrel with Splat 6.1.7 and everything worked correctly. 

Helps prevent against #1462 