### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -86,11 +86,11 @@ dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 
 #Style - qualification options
 
-#prefer events not to be prefaced with this. or Me. in Visual Basic
+#prefer events not to be prefaced with this.
 dotnet_style_qualification_for_event = false:suggestion
-#prefer fields not to be prefaced with this. or Me. in Visual Basic
+#prefer fields not to be prefaced with this.
 dotnet_style_qualification_for_field = false:suggestion
-#prefer methods not to be prefaced with this. or Me. in Visual Basic
+#prefer methods not to be prefaced with this.
 dotnet_style_qualification_for_method = false:suggestion
-#prefer properties not to be prefaced with this. or Me. in Visual Basic
+#prefer properties not to be prefaced with this.
 dotnet_style_qualification_for_property = false:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,96 @@
+[*.cs]
+
+#Core editorconfig formatting - indentation
+
+#use soft tabs (spaces) for indentation
+indent_style = space
+
+#Formatting - indentation options
+
+#indent switch case contents.
+csharp_indent_case_contents = true
+#indent switch labels
+csharp_indent_switch_labels = true
+
+#Formatting - new line options
+
+#place catch statements on a new line
+csharp_new_line_before_catch = true
+#place else statements on a new line
+csharp_new_line_before_else = true
+#require finally statements to be on a new line after the closing brace
+csharp_new_line_before_finally = true
+#require braces to be on a new line for properties, object_collection_array_initializers, types, control_blocks, lambdas, and methods (also known as "Allman" style)
+csharp_new_line_before_open_brace = properties, object_collection_array_initializers, types, control_blocks, lambdas, methods
+
+#Formatting - organize using options
+
+#sort System.* using directives alphabetically, and place them before other usings
+dotnet_sort_system_directives_first = true
+
+#Formatting - spacing options
+
+#require NO space between a cast and the value
+csharp_space_after_cast = false
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_after_colon_in_inheritance_clause = true
+#require a space after a keyword in a control flow statement such as a for loop
+csharp_space_after_keywords_in_control_flow_statements = true
+#require a space before the colon for bases or interfaces in a type declaration
+csharp_space_before_colon_in_inheritance_clause = true
+#remove space within empty argument list parentheses
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+#remove space between method call name and opening parenthesis
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+#do not place space characters after the opening parenthesis and before the closing parenthesis of a method call
+csharp_space_between_method_call_parameter_list_parentheses = false
+#remove space within empty parameter list parentheses for a method declaration
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+#place a space character after the opening parenthesis and before the closing parenthesis of a method declaration parameter list.
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+#Formatting - wrapping options
+
+#leave code block on single line
+csharp_preserve_single_line_blocks = true
+
+#Style - expression bodied member options
+
+#prefer block bodies for accessors
+csharp_style_expression_bodied_accessors = false:suggestion
+#prefer block bodies for constructors
+csharp_style_expression_bodied_constructors = false:suggestion
+#prefer block bodies for methods
+csharp_style_expression_bodied_methods = false:suggestion
+#prefer block bodies for properties
+csharp_style_expression_bodied_properties = false:suggestion
+
+#Style - expression level options
+
+#prefer out variables to be declared before the method call
+csharp_style_inlined_variable_declaration = false:suggestion
+#prefer the type name for member access expressions, instead of the language keyword
+dotnet_style_predefined_type_for_member_access = false:suggestion
+
+#Style - implicit and explicit types
+
+#prefer var is used to declare variables with built-in system types such as int
+csharp_style_var_for_built_in_types = true:suggestion
+#prefer var when the type is already mentioned on the right-hand side of a declaration expression
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+#Style - language keyword and framework type options
+
+#prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+
+#Style - qualification options
+
+#prefer events not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_event = false:suggestion
+#prefer fields not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_field = false:suggestion
+#prefer methods not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_method = false:suggestion
+#prefer properties not to be prefaced with this. or Me. in Visual Basic
+dotnet_style_qualification_for_property = false:suggestion

--- a/Squirrel.sln
+++ b/Squirrel.sln
@@ -20,6 +20,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SyncReleases", "src\SyncRel
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionLevel", "SolutionLevel", "{ED657D2C-F8A0-4012-A64F-7367D41BE4D2}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		src\SolutionAssemblyInfo.cs = src\SolutionAssemblyInfo.cs
 		src\Squirrel.nuspec = src\Squirrel.nuspec
 		vendor\wix\template.wxs = vendor\wix\template.wxs


### PR DESCRIPTION
Fixes #1478

@shiftkey @Thieum I added the .editorconfig generated by IntelliCode to have a starting point. I think it might be a better idea to start from this instead of manually extracting it from the project as it has a lot of inconsistencies.

Unfortunately, IntelliCode can only generate C# code style. My next task is to add C++.

We can then [format all files](https://marketplace.visualstudio.com/items?itemName=munyabe.FormatAllFiles) after the initial .editorconfig is complete.