### PR TITLE
Fix taskbar shorcut update

### DIFF
--- a/src/Squirrel/ShellFile.cs
+++ b/src/Squirrel/ShellFile.cs
@@ -1053,6 +1053,18 @@ namespace Squirrel.Shell
                 this.shortcutFile = linkFile;
             }
         }
+
+        /// <summary>
+        /// Indicates whether the target is in the given directory.
+        /// </summary>
+        /// <param name="directory">The directory.</param>
+        /// <returns>true if the target is in the given directory; otherwise, false.</returns>
+        internal bool IsTargetInDirectory(
+            string directory)
+        {
+            return System.IO.Path.GetDirectoryName(Target)
+                .Equals(directory, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     /// <summary>

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -451,7 +451,7 @@ namespace Squirrel
                     try {
                         if (shortcut == null) continue;
                         if (String.IsNullOrWhiteSpace(shortcut.Target)) continue;
-                        if (!Path.GetDirectoryName(shortcut.Target).Equals(rootAppDirectory, StringComparison.OrdinalIgnoreCase)) continue;
+                        if (!shortcut.IsTargetInDirectory(rootAppDirectory)) continue;
 
                         if (removeAll) {
                             Utility.DeleteFileHarder(shortcut.ShortCutFile);

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -451,7 +451,7 @@ namespace Squirrel
                     try {
                         if (shortcut == null) continue;
                         if (String.IsNullOrWhiteSpace(shortcut.Target)) continue;
-                        if (!shortcut.Target.StartsWith(rootAppDirectory, StringComparison.OrdinalIgnoreCase)) continue;
+                        if (!Path.GetDirectoryName(shortcut.Target).Equals(rootAppDirectory, StringComparison.OrdinalIgnoreCase)) continue;
 
                         if (removeAll) {
                             Utility.DeleteFileHarder(shortcut.ShortCutFile);

--- a/test/ShellLinkTests.cs
+++ b/test/ShellLinkTests.cs
@@ -1,0 +1,23 @@
+﻿using Squirrel.Shell;
+using Xunit;
+
+namespace Squirrel.Tests
+{
+    public class ShellLinkTests
+    {
+        [Theory]
+        [InlineData(@"C:\MyApp\MyApp.exe", @"C:\MyApp", true)]
+        [InlineData(@"C:\MyApp\MyApp.exe", @"C:\MyAppTwo", false)]
+        public void IsTargetInDirectoryTest(
+            string target,
+            string directory,
+            bool isTargetInDirectory)
+        {
+            var shellLink = new ShellLink
+            {
+                Target = target
+            };
+            Assert.Equal(isTargetInDirectory, shellLink.IsTargetInDirectory(directory));
+        }
+    }
+}

--- a/test/Squirrel.Tests.csproj
+++ b/test/Squirrel.Tests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReleaseEntryTests.cs" />
     <Compile Include="ReleasePackageTests.cs" />
+    <Compile Include="ShellLinkTests.cs" />
     <Compile Include="SquirrelAwareExecutableDetectorTests.cs" />
     <Compile Include="TestHelpers\AssertExtensions.cs" />
     <Compile Include="TestHelpers\ExposedClass.cs" />


### PR DESCRIPTION
Fixes #1238 

Not sure but it may be using `StartsWith` before to consider if target is in a subdirectory?
e.g.
   target: `C:\MyApp\Subdirectory\MyApp.exe`
   directory: `C:\MyApp`
   expected: `true`