### PR TITLE
docs: add console app is not supported

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,12 +13,15 @@ Frequently Asked Questions for Squirrel.Windows, organized by area below.
    You may want to look into the [ClickOnceToSquirrelMigrator](https://github.com/flagbug/ClickOnceToSquirrelMigrator) migration helper.
 1. **How can I determine if my app is a Squirrel app? I provide a squirrel and non-squirrel install version and want to know which is running.**  
    You can check for the `Update.exe` in the parent directory to determine if the app is using Squirrel ([see #574](https://github.com/Squirrel/Squirrel.Windows/issues/574#issuecomment-176043311)).
-   
-```
-var assembly = Assembly.GetEntryAssembly();   
-var updateDotExe = Path.Combine(Path.GetDirectoryName(assembly.Location), "..", "Update.exe");
-var isSquirrelInstall = File.Exists(updateDotExe);
-```
+
+    ```
+    var assembly = Assembly.GetEntryAssembly();   
+    var updateDotExe = Path.Combine(Path.GetDirectoryName(assembly.Location), "..", "Update.exe");
+    var isSquirrelInstall = File.Exists(updateDotExe);
+    ```
+
+1. **Why can't I integrate my console application to Squirrel.Windows**
+   Console application is currently not supported. Subscribe to [#1098](https://github.com/Squirrel/Squirrel.Windows/issues/1098) to keep track of this issue.
 
 ## Packaging
 


### PR DESCRIPTION
Update docs so we can close #996.
Keep #1098 open to keep track of issue.

Need to indent the code for 3rd item to have VS code parse the markdown list properly. Also looks clearer that the code is meant for that item.