### PR TITLE
Fix deployment tool install check

### DIFF
--- a/src/Setup/MachineInstaller.cpp
+++ b/src/Setup/MachineInstaller.cpp
@@ -22,7 +22,7 @@ bool directoryExists(wchar_t* path) {
 bool MachineInstaller::ShouldSilentInstall()
 {
 	// Figure out the package name from our own EXE name 
-	// The name is consist of $pkgNameDeploymentTool.exe
+	// The name consist of [$pkgName]DeploymentTool.exe
 	wchar_t ourFile[MAX_PATH];
 	HMODULE hMod = GetModuleHandle(NULL);
 	GetModuleFileName(hMod, ourFile, _countof(ourFile));

--- a/src/Setup/MachineInstaller.cpp
+++ b/src/Setup/MachineInstaller.cpp
@@ -22,13 +22,14 @@ bool directoryExists(wchar_t* path) {
 bool MachineInstaller::ShouldSilentInstall()
 {
 	// Figure out the package name from our own EXE name 
+	// The name is consist of $pkgNameDeploymentTool.exe
 	wchar_t ourFile[MAX_PATH];
 	HMODULE hMod = GetModuleHandle(NULL);
 	GetModuleFileName(hMod, ourFile, _countof(ourFile));
 
 	CString fullPath = CString(ourFile);
 	CString pkgName = CString(ourFile + fullPath.ReverseFind(L'\\'));
-	pkgName.Replace(L".exe", L"");
+	pkgName.Replace(L"DeploymentTool.exe", L"");
 	
 	wchar_t installFolder[MAX_PATH];
 


### PR DESCRIPTION
With the renaming of the MachineWide installer to DeploymentTool a little bug got introduced and cause the Setup not to install the App when a user logs in. This PR takes care of it by accounting for the now differently named installer and extracting the package name correctly.