### PR TITLE
fix: run reg key 

### DIFF
--- a/vendor/wix/template.wxs
+++ b/vendor/wix/template.wxs
@@ -26,7 +26,7 @@
     <DirectoryRef Id="TARGETDIR">
       <Component Id="RegistryEntries" Guid="{{IdAsGuid3}}" Win64="{{Win64YesNo}}">
         <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Run">
-          <RegistryValue Type="expandable" Name="{{Id}}MachineInstaller" Value="%ProgramFiles%\{{Title}} Deployment\{{Id}}DeploymentTool.exe --checkInstall" />
+          <RegistryValue Type="expandable" Name="{{Id}}Deployment" Value="&quot;[#{{Id}}.exe]&quot; --checkInstall" />
         </RegistryKey>
       </Component>
     </DirectoryRef>


### PR DESCRIPTION
This fixes the registry run key for app deployment. The 32bit MSI on 64bit OS will now have the correct path. The registry key value uses a reference to the installed file instead of static entry and therefore should be always correct. The registry key is also renamed to fit with the rest of the naming in the context of the MSI.