### PR TITLE
Update Pinned TaskBar Log

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -436,7 +436,7 @@ namespace Squirrel
 
                 var resolveLink = new Func<FileInfo, ShellLink>(file => {
                     try {
-                        this.Log().Info("Examining Pin: " + file);
+                        this.Log().Debug("Examining Pin: " + file);
                         return new ShellLink(file.FullName);
                     } catch (Exception ex) {
                         var message = String.Format("File '{0}' could not be converted into a valid ShellLink", file.FullName);


### PR DESCRIPTION
We've had experience from Users thinking we are collecting their computer's data because this function is logging each `.lnk` file not related to our application.

This pull request proposes a change to the `fixPinnedExecutables` logging from `Info` to `Debug` so that it is not logged to file.