### PR TITLE
Remove Splat External Dependency

### DIFF
--- a/src/Setup/FxHelper.cpp
+++ b/src/Setup/FxHelper.cpp
@@ -16,7 +16,7 @@ static const int fx472ReleaseVersion = 461808; // Minimum version for .NET 4.7.2
 
 // According to https://msdn.microsoft.com/en-us/library/8z6watww%28v=vs.110%29.aspx,
 // to install .NET 4.5 we must be Vista SP2+, Windows 7 SP1+, or later.
-// However Paul thinks this is just for customer support, anything >= Vista will generally work.
+// However Anaïs thinks this is just for customer support, anything >= Vista will generally work.
 bool CFxHelper::CanInstallDotNet4_5()
 {
 	return IsWindowsVistaOrGreater();

--- a/src/Setup/Setup.vcxproj
+++ b/src/Setup/Setup.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{C1D40624-A484-438A-B846-052F321C89D1}</ProjectGuid>
     <ConfigurationType>Application</ConfigurationType>
     <Keyword>Win32Proj</Keyword>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <RootNamespace>Setup</RootNamespace>
   </PropertyGroup>

--- a/src/Setup/Setup.vcxproj
+++ b/src/Setup/Setup.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{C1D40624-A484-438A-B846-052F321C89D1}</ProjectGuid>
     <ConfigurationType>Application</ConfigurationType>
     <Keyword>Win32Proj</Keyword>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <RootNamespace>Setup</RootNamespace>
   </PropertyGroup>

--- a/src/Squirrel.nuspec
+++ b/src/Squirrel.nuspec
@@ -3,14 +3,13 @@
   <metadata>
     <version>1.9.1</version>
     <authors>GitHub</authors>
-    <owners>Paul Betts</owners>
+    <owners>Anaïs Betts</owners>
     <licenseUrl>https://github.com/squirrel/Squirrel.Windows/blob/master/COPYING</licenseUrl>
     <projectUrl>https://github.com/squirrel/Squirrel.Windows</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/Squirrel/Squirrel.Windows/master/docs/artwork/Squirrel-Logo-Square.png</iconUrl>
 
     <dependencies>
       <dependency id="DeltaCompressionDotNet" version="[1.1,2.0)" />
-      <dependency id="Splat" version="[1.6.2,7.0)" />
       <dependency id="Mono.Cecil" version="0.9.6.1" />
       <dependency id="SharpCompress" version="[0.17.1]" />
     </dependencies>

--- a/src/Squirrel/DeltaPackage.cs
+++ b/src/Squirrel/DeltaPackage.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using Splat;
+using Squirrel.SimpleSplat;
 using DeltaCompressionDotNet.MsDelta;
 using System.ComponentModel;
 using Squirrel.Bsdiff;

--- a/src/Squirrel/FileDownloader.cs
+++ b/src/Squirrel/FileDownloader.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Threading.Tasks;
-using Splat;
+using Squirrel.SimpleSplat;
 
 namespace Squirrel
 {

--- a/src/Squirrel/IUpdateManager.cs
+++ b/src/Squirrel/IUpdateManager.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32;
-using Splat;
+using Squirrel.SimpleSplat;
 using NuGet;
 
 namespace Squirrel

--- a/src/Squirrel/ReleaseEntry.cs
+++ b/src/Squirrel/ReleaseEntry.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using NuGet;
-using Splat;
+using Squirrel.SimpleSplat;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using System.Collections.Concurrent;

--- a/src/Squirrel/ReleasePackage.cs
+++ b/src/Squirrel/ReleasePackage.cs
@@ -11,7 +11,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using MarkdownSharp;
 using NuGet;
-using Splat;
+using Squirrel.SimpleSplat;
 using System.Threading.Tasks;
 using SharpCompress.Archives.Zip;
 using SharpCompress.Readers;

--- a/src/Squirrel/SimpleSplat/AssemblyFinder.cs
+++ b/src/Squirrel/SimpleSplat/AssemblyFinder.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Squirrel.SimpleSplat
+{
+    static class AssemblyFinder
+    {
+        public static T AttemptToLoadType<T>(string fullTypeName)
+        {
+            var thisType = typeof(AssemblyFinder);
+
+            var toSearch = new[] {
+                thisType.AssemblyQualifiedName.Replace(thisType.FullName + ", ", ""),
+                thisType.AssemblyQualifiedName.Replace(thisType.FullName + ", ", "").Replace(".Portable", ""),
+            }.Select(x => new AssemblyName(x)).ToArray();
+
+            foreach (var assembly in toSearch) {
+                var fullName = fullTypeName + ", " + assembly.FullName; 
+                var type = Type.GetType(fullName, false);
+                if (type == null) continue;
+
+                return (T)Activator.CreateInstance(type);
+            }
+
+            return default(T);
+        }
+    }
+}

--- a/src/Squirrel/SimpleSplat/Logging.cs
+++ b/src/Squirrel/SimpleSplat/Logging.cs
@@ -1,0 +1,580 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reflection;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+
+namespace Squirrel.SimpleSplat
+{
+    /*    
+     * Interfaces
+     */
+
+    public enum LogLevel {
+        Debug = 1, Info, Warn, Error, Fatal,
+    }
+
+    public interface ILogger
+    {
+        void Write([Localizable(false)] string message, LogLevel logLevel);
+        LogLevel Level { get; set; }
+    }
+
+    public interface IFullLogger : ILogger
+    {
+        void Debug<T>(T value);
+        void Debug<T>(IFormatProvider formatProvider, T value);
+        void DebugException([Localizable(false)] string message, Exception exception);
+        void Debug(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
+        void Debug([Localizable(false)] string message);
+        void Debug([Localizable(false)] string message, params object[] args);
+        void Debug<TArgument>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument);
+        void Debug<TArgument>([Localizable(false)] string message, TArgument argument);
+        void Debug<TArgument1, TArgument2>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Debug<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+
+        void Info<T>(T value);
+        void Info<T>(IFormatProvider formatProvider, T value);
+        void InfoException([Localizable(false)] string message, Exception exception);
+        void Info(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
+        void Info([Localizable(false)] string message);
+        void Info([Localizable(false)] string message, params object[] args);
+        void Info<TArgument>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument);
+        void Info<TArgument>([Localizable(false)] string message, TArgument argument);
+        void Info<TArgument1, TArgument2>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Info<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+
+        void Warn<T>(T value);
+        void Warn<T>(IFormatProvider formatProvider, T value);
+        void WarnException([Localizable(false)] string message, Exception exception);
+        void Warn(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
+        void Warn([Localizable(false)] string message);
+        void Warn([Localizable(false)] string message, params object[] args);
+        void Warn<TArgument>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument);
+        void Warn<TArgument>([Localizable(false)] string message, TArgument argument);
+        void Warn<TArgument1, TArgument2>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Warn<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+
+        void Error<T>(T value);
+        void Error<T>(IFormatProvider formatProvider, T value);
+        void ErrorException([Localizable(false)] string message, Exception exception);
+        void Error(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
+        void Error([Localizable(false)] string message);
+        void Error([Localizable(false)] string message, params object[] args);
+        void Error<TArgument>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument);
+        void Error<TArgument>([Localizable(false)] string message, TArgument argument);
+        void Error<TArgument1, TArgument2>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Error<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+
+        void Fatal<T>(T value);
+        void Fatal<T>(IFormatProvider formatProvider, T value);
+        void FatalException([Localizable(false)] string message, Exception exception);
+        void Fatal(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args);
+        void Fatal([Localizable(false)] string message);
+        void Fatal([Localizable(false)] string message, params object[] args);
+        void Fatal<TArgument>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument argument);
+        void Fatal<TArgument>([Localizable(false)] string message, TArgument argument);
+        void Fatal<TArgument1, TArgument2>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Fatal<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+    }
+
+    public interface ILogManager
+    {
+        IFullLogger GetLogger(Type type);
+    }
+
+    public class DefaultLogManager : ILogManager
+    {
+        readonly MemoizingMRUCache<Type, IFullLogger> loggerCache;
+
+        public DefaultLogManager(IDependencyResolver dependencyResolver = null)
+        {
+            dependencyResolver = dependencyResolver ?? Locator.Current;
+
+            loggerCache = new MemoizingMRUCache<Type, IFullLogger>((type, _) => {
+                var ret = dependencyResolver.GetService<ILogger>();
+                if (ret == null) {
+                    throw new Exception("Couldn't find an ILogger. This should never happen, your dependency resolver is probably broken.");
+                }
+
+                return new WrappingFullLogger(ret, type);
+            }, 64);
+        }
+
+        static readonly IFullLogger nullLogger = new WrappingFullLogger(new NullLogger(), typeof(MemoizingMRUCache<Type, IFullLogger>));
+        public IFullLogger GetLogger(Type type)
+        {
+            if (LogHost.suppressLogging) return nullLogger;
+            if (type == typeof(MemoizingMRUCache<Type, IFullLogger>)) return nullLogger;
+
+            lock (loggerCache) {
+                return loggerCache.Get(type);
+            }
+        }
+    }
+
+    public class FuncLogManager : ILogManager
+    {
+        readonly Func<Type, IFullLogger> _inner;
+        public FuncLogManager(Func<Type, IFullLogger> getLogger)
+        {
+            _inner = getLogger;
+        }
+
+        public IFullLogger GetLogger(Type type)
+        {
+            return _inner(type);
+        }
+    }
+
+    public static class LogManagerMixin
+    {
+        public static IFullLogger GetLogger<T>(this ILogManager This)
+        {
+            return This.GetLogger(typeof(T));
+        }
+    }
+
+    public class NullLogger : ILogger
+    {
+        public void Write(string message, LogLevel logLevel) {}
+        public LogLevel Level { get; set; }
+    }
+
+    public class DebugLogger : ILogger
+    {
+        public void Write(string message, LogLevel logLevel)
+        {
+            if ((int)logLevel < (int)Level) return;
+            Debug.WriteLine(message);
+        }
+
+        public LogLevel Level { get; set; }
+    }
+
+
+    /*    
+     * LogHost / Logging Mixin
+     */
+
+    /// <summary>
+    /// "Implement" this interface in your class to get access to the Log() 
+    /// Mixin, which will give you a Logger that includes the class name in the
+    /// log.
+    /// </summary>
+    [System.Runtime.InteropServices.ComVisible(false)]
+    public interface IEnableLogger { }
+
+    public static class LogHost
+    {
+        static internal bool suppressLogging = false;
+        static readonly IFullLogger nullLogger = new WrappingFullLogger(new NullLogger(), typeof(string));
+
+        /// <summary>
+        /// Use this logger inside miscellaneous static methods where creating
+        /// a class-specific logger isn't really worth it.
+        /// </summary>
+        public static IFullLogger Default {
+            get {
+                if (suppressLogging) return nullLogger;
+
+                var factory = Locator.Current.GetService<ILogManager>();
+                if (factory == null) {
+                    throw new Exception("ILogManager is null. This should never happen, your dependency resolver is broken");
+                }
+                return factory.GetLogger(typeof(LogHost));
+            }
+        }
+
+        /// <summary>
+        /// Call this method to write log entries on behalf of the current 
+        /// class.
+        /// </summary>
+        public static IFullLogger Log<T>(this T This) where T : IEnableLogger
+        {
+            if (suppressLogging) return nullLogger;
+
+            var factory = Locator.Current.GetService<ILogManager>();
+            if (factory == null) {
+                throw new Exception("ILogManager is null. This should never happen, your dependency resolver is broken");
+            }
+
+            return factory.GetLogger<T>();
+        }
+    }
+
+    #region Extremely Dull Code Ahead
+    public class WrappingFullLogger : IFullLogger
+    {
+        readonly ILogger _inner;
+        readonly string prefix;
+        readonly MethodInfo stringFormat;
+
+        public WrappingFullLogger(ILogger inner, Type callingType)
+        {
+            _inner = inner;
+            prefix = String.Format(CultureInfo.InvariantCulture, "{0}: ", callingType.Name);
+
+            stringFormat = typeof (String).GetMethod("Format", new[] {typeof (IFormatProvider), typeof (string), typeof (object[])});
+            Contract.Requires(inner != null);
+            Contract.Requires(stringFormat != null);
+        }
+
+        string InvokeStringFormat(IFormatProvider formatProvider, string message, object[] args)
+        {
+            var sfArgs = new object[3];
+            sfArgs[0] = formatProvider;
+            sfArgs[1] = message;
+            sfArgs[2] = args;
+            return (string) stringFormat.Invoke(null, sfArgs);
+        }
+
+        public void Debug<T>(T value)
+        {
+            _inner.Write(prefix + value, LogLevel.Debug);
+        }
+
+        public void Debug<T>(IFormatProvider formatProvider, T value)
+        {
+            _inner.Write(String.Format(formatProvider, "{0}{1}", prefix, value), LogLevel.Debug);
+        }
+
+        public void DebugException(string message, Exception exception)
+        {
+            _inner.Write(String.Format("{0}{1}: {2}", prefix, message, exception), LogLevel.Debug);
+        }
+
+        public void Debug(IFormatProvider formatProvider, string message, params object[] args)
+        {
+            var result = InvokeStringFormat(formatProvider, message, args);
+
+            _inner.Write(prefix + result, LogLevel.Debug);
+        }
+
+
+        public void Debug(string message)
+        {
+            _inner.Write(prefix + message, LogLevel.Debug);
+        }
+
+        public void Debug(string message, params object[] args)
+        {
+            var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
+            _inner.Write(prefix + result, LogLevel.Debug);
+        }
+
+        public void Debug<TArgument>(IFormatProvider formatProvider, string message, TArgument argument)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument), LogLevel.Debug);
+        }
+
+        public void Debug<TArgument>(string message, TArgument argument)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Debug);
+        }
+
+        public void Debug<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2), LogLevel.Debug);
+        }
+
+        public void Debug<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Debug);
+        }
+
+        public void Debug<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Debug);
+        }
+
+        public void Debug<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Debug);
+        }
+
+        public void Info<T>(T value)
+        {
+            _inner.Write(prefix + value, LogLevel.Info);
+        }
+
+        public void Info<T>(IFormatProvider formatProvider, T value)
+        {
+            _inner.Write(String.Format(formatProvider, "{0}{1}", prefix, value), LogLevel.Info);
+        }
+
+        public void InfoException(string message, Exception exception)
+        {
+            _inner.Write(String.Format("{0}{1}: {2}", prefix, message, exception), LogLevel.Info);
+        }
+
+        public void Info(IFormatProvider formatProvider, string message, params object[] args)
+        {
+            var result = InvokeStringFormat(formatProvider, message, args);
+            _inner.Write(prefix + result, LogLevel.Info);
+        }
+
+        public void Info(string message)
+        {
+            _inner.Write(prefix + message, LogLevel.Info);
+        }
+
+        public void Info(string message, params object[] args)
+        {
+            var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
+            _inner.Write(prefix + result, LogLevel.Info);
+        }
+
+        public void Info<TArgument>(IFormatProvider formatProvider, string message, TArgument argument)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument), LogLevel.Info);
+        }
+
+        public void Info<TArgument>(string message, TArgument argument)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Info);
+        }
+
+        public void Info<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2), LogLevel.Info);
+        }
+
+        public void Info<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Info);
+        }
+
+        public void Info<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Info);
+        }
+
+        public void Info<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Info);
+        }
+
+        public void Warn<T>(T value)
+        {
+            _inner.Write(prefix + value, LogLevel.Warn);
+        }
+
+        public void Warn<T>(IFormatProvider formatProvider, T value)
+        {
+            _inner.Write(String.Format(formatProvider, "{0}{1}", prefix, value), LogLevel.Warn);
+        }
+
+        public void WarnException(string message, Exception exception)
+        {
+            _inner.Write(String.Format("{0}{1}: {2}", prefix, message, exception), LogLevel.Warn);
+        }
+
+        public void Warn(IFormatProvider formatProvider, string message, params object[] args)
+        {
+            var result = InvokeStringFormat(formatProvider, message, args);
+            _inner.Write(prefix + result, LogLevel.Warn);
+        }
+
+        public void Warn(string message)
+        {
+            _inner.Write(prefix + message, LogLevel.Warn);
+        }
+
+        public void Warn(string message, params object[] args)
+        {
+            var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
+            _inner.Write(prefix + result, LogLevel.Warn);
+        }
+
+        public void Warn<TArgument>(IFormatProvider formatProvider, string message, TArgument argument)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument), LogLevel.Warn);
+        }
+
+        public void Warn<TArgument>(string message, TArgument argument)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Warn);
+        }
+
+        public void Warn<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2), LogLevel.Warn);
+        }
+
+        public void Warn<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Warn);
+        }
+
+        public void Warn<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Warn);
+        }
+
+        public void Warn<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Warn);
+        }
+
+
+        public void Error<T>(T value)
+        {
+            _inner.Write(prefix + value, LogLevel.Error);
+        }
+
+        public void Error<T>(IFormatProvider formatProvider, T value)
+        {
+            _inner.Write(String.Format(formatProvider, "{0}{1}", prefix, value), LogLevel.Error);
+        }
+
+        public void ErrorException(string message, Exception exception)
+        {
+            _inner.Write(String.Format("{0}{1}: {2}", prefix, message, exception), LogLevel.Error);
+        }
+
+        public void Error(IFormatProvider formatProvider, string message, params object[] args)
+        {
+            var result = InvokeStringFormat(formatProvider, message, args);
+            _inner.Write(prefix + result, LogLevel.Error);
+        }
+
+        public void Error(string message)
+        {
+            _inner.Write(prefix + message, LogLevel.Error);
+        }
+
+        public void Error(string message, params object[] args)
+        {
+            var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
+            _inner.Write(prefix + result, LogLevel.Error);
+        }
+
+        public void Error<TArgument>(IFormatProvider formatProvider, string message, TArgument argument)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument), LogLevel.Error);
+        }
+
+        public void Error<TArgument>(string message, TArgument argument)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Error);
+        }
+
+        public void Error<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2), LogLevel.Error);
+        }
+
+        public void Error<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Error);
+        }
+
+        public void Error<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Error);
+        }
+
+        public void Error<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Error);
+        }
+
+
+        public void Fatal<T>(T value)
+        {
+            _inner.Write(prefix + value, LogLevel.Fatal);
+        }
+
+        public void Fatal<T>(IFormatProvider formatProvider, T value)
+        {
+            _inner.Write(String.Format(formatProvider, "{0}{1}", prefix, value), LogLevel.Fatal);
+        }
+
+        public void FatalException(string message, Exception exception)
+        {
+            _inner.Write(String.Format("{0}{1}: {2}", prefix, message, exception), LogLevel.Fatal);
+        }
+
+        public void Fatal(IFormatProvider formatProvider, string message, params object[] args)
+        {
+            var result = InvokeStringFormat(formatProvider, message, args);
+            _inner.Write(prefix + result, LogLevel.Fatal);
+        }
+
+        public void Fatal(string message)
+        {
+            _inner.Write(prefix + message, LogLevel.Fatal);
+        }
+
+        public void Fatal(string message, params object[] args)
+        {
+            var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
+            _inner.Write(prefix + result, LogLevel.Fatal);
+        }
+
+        public void Fatal<TArgument>(IFormatProvider formatProvider, string message, TArgument argument)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument), LogLevel.Fatal);
+        }
+
+        public void Fatal<TArgument>(string message, TArgument argument)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Fatal);
+        }
+
+        public void Fatal<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2), LogLevel.Fatal);
+        }
+
+        public void Fatal<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Fatal);
+        }
+
+        public void Fatal<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Fatal);
+        }
+
+        public void Fatal<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
+        {
+            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Fatal);
+        }
+
+        public void Write([Localizable(false)] string message, LogLevel logLevel)
+        {
+            _inner.Write(message, logLevel);
+        }
+
+        public LogLevel Level {
+            get { return _inner.Level; }
+            set { _inner.Level = value; }
+        }
+    }
+    #endregion
+
+    #if PORTABLE || WINDOWS_PHONE || NETFX_CORE
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    public sealed class LocalizableAttribute : Attribute
+    {
+        public LocalizableAttribute(bool isLocalizable) { }
+    }
+    #endif
+}
+
+// vim: tw=120 ts=4 sw=4 et :

--- a/src/Squirrel/SimpleSplat/MemoizingMRUCache.cs
+++ b/src/Squirrel/SimpleSplat/MemoizingMRUCache.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Diagnostics.Contracts;
+
+namespace Squirrel.SimpleSplat
+{
+    /// <summary>
+    /// This data structure is a representation of a memoizing cache - i.e. a
+    /// class that will evaluate a function, but keep a cache of recently
+    /// evaluated parameters.
+    ///
+    /// Since this is a memoizing cache, it is important that this function be a
+    /// "pure" function in the mathematical sense - that a key *always* maps to
+    /// a corresponding return value.
+    /// </summary>
+    /// <typeparam name="TParam">The type of the parameter to the calculation function.</typeparam>
+    /// <typeparam name="TVal">The type of the value returned by the calculation
+    /// function.</typeparam>
+    public class MemoizingMRUCache<TParam, TVal>
+    {
+        private readonly Func<TParam, object, TVal> calculationFunction;
+        private readonly Action<TVal> releaseFunction;
+        private readonly int maxCacheSize;
+
+        private LinkedList<TParam> cacheMRUList;
+        private Dictionary<TParam, Tuple<LinkedListNode<TParam>, TVal>> cacheEntries;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="calculationFunc">The function whose results you want to cache,
+        /// which is provided the key value, and an Tag object that is
+        /// user-defined</param>
+        /// <param name="maxSize">The size of the cache to maintain, after which old
+        /// items will start to be thrown out.</param>
+        /// <param name="onRelease">A function to call when a result gets
+        /// evicted from the cache (i.e. because Invalidate was called or the
+        /// cache is full)</param>
+        public MemoizingMRUCache(Func<TParam, object, TVal> calculationFunc, int maxSize, Action<TVal> onRelease = null)
+        {
+            Contract.Requires(calculationFunc != null);
+            Contract.Requires(maxSize > 0);
+
+            calculationFunction = calculationFunc;
+            releaseFunction = onRelease;
+            maxCacheSize = maxSize;
+            InvalidateAll();
+        }
+
+        public TVal Get(TParam key) { return Get(key, null); }
+
+        /// <summary>
+        /// Evaluates the function provided, returning the cached value if possible
+        /// </summary>
+        /// <param name="key">The value to pass to the calculation function.</param>
+        /// <param name="context">An additional optional user-specific parameter.</param>
+        /// <returns></returns>
+        public TVal Get(TParam key, object context = null)
+        {
+            Contract.Requires(key != null);
+
+            if (cacheEntries.ContainsKey(key)) {
+                var found = cacheEntries[key];
+                cacheMRUList.Remove(found.Item1);
+                cacheMRUList.AddFirst(found.Item1);
+                return found.Item2;
+            }
+
+            var result = calculationFunction(key, context);
+
+            var node = new LinkedListNode<TParam>(key);
+            cacheMRUList.AddFirst(node);
+            cacheEntries[key] = new Tuple<LinkedListNode<TParam>, TVal>(node, result);
+            maintainCache();
+
+            return result;
+        }
+
+        public bool TryGet(TParam key, out TVal result)
+        {
+            Contract.Requires(key != null);
+
+            Tuple<LinkedListNode<TParam>, TVal> output;
+            var ret = cacheEntries.TryGetValue(key, out output);
+            if (ret && output != null) {
+                cacheMRUList.Remove(output.Item1);
+                cacheMRUList.AddFirst(output.Item1);
+                result = output.Item2;
+            } else {
+                result = default(TVal);
+            }
+            return ret;
+        }
+
+        /// <summary>
+        /// Ensure that the next time this key is queried, the calculation
+        /// function will be called.
+        /// </summary>
+        public void Invalidate(TParam key)
+        {
+            Contract.Requires(key != null);
+
+            if (!cacheEntries.ContainsKey(key))
+                return;
+
+            var to_remove = cacheEntries[key];
+            if (releaseFunction != null)
+                releaseFunction(to_remove.Item2);
+
+            cacheMRUList.Remove(to_remove.Item1);
+            cacheEntries.Remove(key);
+        }
+
+        /// <summary>
+        /// Invalidate all items in the cache
+        /// </summary>
+        public void InvalidateAll()
+        {
+            if (releaseFunction == null || cacheEntries == null) {
+                cacheMRUList = new LinkedList<TParam>();
+                cacheEntries = new Dictionary<TParam, Tuple<LinkedListNode<TParam>, TVal>>();
+                return;
+            }
+
+            if (cacheEntries.Count == 0)
+                return;
+
+            /*             We have to remove them one-by-one to call the release function
+             * We ToArray() this so we don't get a "modifying collection while
+             * enumerating" exception. */
+            foreach (var v in cacheEntries.Keys.ToArray()) { Invalidate(v); }
+        }
+
+        /// <summary>
+        /// Returns all values currently in the cache
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<TVal> CachedValues()
+        {
+            return cacheEntries.Select(x => x.Value.Item2);
+        }
+
+        void maintainCache()
+        {
+            while (cacheMRUList.Count > maxCacheSize) {
+                var to_remove = cacheMRUList.Last.Value;
+                if (releaseFunction != null)
+                    releaseFunction(cacheEntries[to_remove].Item2);
+
+                cacheEntries.Remove(cacheMRUList.Last.Value);
+                cacheMRUList.RemoveLast();
+            }
+        }
+
+        [ContractInvariantMethod]
+        void Invariants()
+        {
+            Contract.Invariant(cacheEntries.Count == cacheMRUList.Count);
+            Contract.Invariant(cacheEntries.Count <= maxCacheSize);
+        }
+    }
+}
+
+// vim: tw=120 ts=4 sw=4 et :

--- a/src/Squirrel/SimpleSplat/ModeDetector.cs
+++ b/src/Squirrel/SimpleSplat/ModeDetector.cs
@@ -1,0 +1,79 @@
+using System;
+
+namespace Squirrel.SimpleSplat
+{
+    public interface IModeDetector
+    {
+        bool? InUnitTestRunner();
+        bool? InDesignMode();
+    }
+
+    public static class ModeDetector
+    {
+        static ModeDetector()
+        {
+            var platModeDetector = AssemblyFinder.AttemptToLoadType<IModeDetector>("Squirrel.SimpleSplat.PlatformModeDetector");
+            current = platModeDetector;
+        }
+
+        static IModeDetector current { get; set; }
+
+        public static void OverrideModeDetector(IModeDetector modeDetector)
+        {
+            current = modeDetector;
+            cachedInDesignModeResult = null;
+            cachedInUnitTestRunnerResult = null;
+        }
+
+        static bool? cachedInUnitTestRunnerResult;
+        public static bool InUnitTestRunner() 
+        {
+            if (cachedInUnitTestRunnerResult.HasValue) return cachedInUnitTestRunnerResult.Value;
+
+            if (current != null) {
+                cachedInUnitTestRunnerResult = current.InUnitTestRunner();
+                if (cachedInUnitTestRunnerResult.HasValue) return cachedInUnitTestRunnerResult.Value;
+            }
+
+            // We have no sane platform-independent way to detect a unit test 
+            // runner :-/
+            return false;
+        }
+                
+        static bool? cachedInDesignModeResult;
+        public static bool InDesignMode()
+        {
+            if (cachedInDesignModeResult.HasValue) return cachedInDesignModeResult.Value;
+
+            if (current != null) {
+                cachedInDesignModeResult = current.InDesignMode();
+                if (cachedInDesignModeResult.HasValue) return cachedInDesignModeResult.Value;
+            }
+            
+            // Check Silverlight / WP8 Design Mode
+            var type = Type.GetType("System.ComponentModel.DesignerProperties, System.Windows, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e", false);
+            if (type != null) {
+                var mInfo = type.GetMethod("GetIsInDesignMode");
+                var dependencyObject = Type.GetType("System.Windows.Controls.Border, System.Windows, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e", false);
+
+                if (dependencyObject != null) {
+                    cachedInDesignModeResult = (bool)mInfo.Invoke(null, new object[] { Activator.CreateInstance(dependencyObject) });
+                }
+            } else if((type = Type.GetType("System.ComponentModel.DesignerProperties, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35", false)) != null) {
+                // loaded the assembly, could be .net 
+                var mInfo = type.GetMethod("GetIsInDesignMode");
+                Type dependencyObject = Type.GetType("System.Windows.DependencyObject, WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35", false);
+                if (dependencyObject != null) {
+                    cachedInDesignModeResult = (bool)mInfo.Invoke(null, new object[] { Activator.CreateInstance(dependencyObject) });
+                }
+            } else if ((type = Type.GetType("Windows.ApplicationModel.DesignMode, Windows, ContentType=WindowsRuntime", false)) != null) {
+                // check WinRT next
+                cachedInDesignModeResult = (bool)type.GetProperty("DesignModeEnabled").GetMethod.Invoke(null, null);
+            } else {
+                cachedInDesignModeResult = false;
+            }
+
+            return cachedInDesignModeResult.GetValueOrDefault();
+        }
+    }
+}

--- a/src/Squirrel/SimpleSplat/PlatformModeDetector.cs
+++ b/src/Squirrel/SimpleSplat/PlatformModeDetector.cs
@@ -1,0 +1,84 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+#if SILVERLIGHT
+using System.Windows;
+#elif NETFX_CORE
+using Windows.ApplicationModel;
+#endif
+
+namespace Squirrel.SimpleSplat
+{
+    public class PlatformModeDetector : IModeDetector
+    {
+        public bool? InUnitTestRunner()
+        {
+            var testAssemblies = new[] {
+                "CSUNIT",
+                "NUNIT",
+                "XUNIT",
+                "MBUNIT",
+                "NBEHAVE",
+            };
+
+            try {
+                return searchForAssembly(testAssemblies);
+            } catch (Exception) {
+                return null;
+            }
+        }
+
+        public bool? InDesignMode()
+        {
+#if SILVERLIGHT
+            if (Application.Current.RootVisual != null) {
+                return System.ComponentModel.DesignerProperties.GetIsInDesignMode(Application.Current.RootVisual);
+            }
+
+            return false;
+#elif NETFX_CORE
+            return DesignMode.DesignModeEnabled;
+#else
+            var designEnvironments = new[] {
+                "BLEND.EXE",
+                "XDESPROC.EXE",
+            };
+
+            var entry = Assembly.GetEntryAssembly();
+            if (entry != null) {
+                var exeName = (new FileInfo(entry.Location)).Name.ToUpperInvariant();
+
+                if (designEnvironments.Any(x => x.Contains(exeName))) {
+                    return true;
+                }
+            }
+
+            return false;
+#endif
+        }
+        
+        static bool searchForAssembly(IEnumerable<string> assemblyList)
+        {
+#if SILVERLIGHT
+            return Deployment.Current.Parts.Any(x => assemblyList.Any(name => x.Source.ToUpperInvariant().Contains(name)));
+#elif NETFX_CORE
+            var depPackages = Package.Current.Dependencies.Select(x => x.Id.FullName);
+            if (depPackages.Any(x => assemblyList.Any(name => x.ToUpperInvariant().Contains(name)))) return true;
+
+            var fileTask = Task.Factory.StartNew(async () => {
+                var files = await Package.Current.InstalledLocation.GetFilesAsync();
+                return files.Select(x => x.Path).ToArray();
+            }, TaskCreationOptions.HideScheduler).Unwrap();
+
+            return fileTask.Result.Any(x => assemblyList.Any(name => x.ToUpperInvariant().Contains(name)));
+#else
+            return AppDomain.CurrentDomain.GetAssemblies()
+                .Any(x => assemblyList.Any(name => x.FullName.ToUpperInvariant().Contains(name)));
+#endif
+        }
+    }
+}

--- a/src/Squirrel/SimpleSplat/ServiceLocation.cs
+++ b/src/Squirrel/SimpleSplat/ServiceLocation.cs
@@ -1,0 +1,423 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Squirrel.SimpleSplat
+{
+    public static class Locator
+    {
+        [ThreadStatic] static IDependencyResolver unitTestDependencyResolver;
+        static IDependencyResolver dependencyResolver;
+
+        static readonly List<Action> resolverChanged = new List<Action>();
+
+        static Locator()
+        {
+            var r = new ModernDependencyResolver();
+            dependencyResolver = r;
+
+            RegisterResolverCallbackChanged(() => {
+                if (Locator.CurrentMutable == null) return;
+                Locator.CurrentMutable.InitializeSplat();
+            });
+        }
+
+        /// <summary>
+        /// Gets or sets the dependency resolver. This class is used throughout
+        /// libraries for many internal operations as well as for general use
+        /// by applications. If this isn't assigned on startup, a default, highly
+        /// capable implementation will be used, and it is advised for most people
+        /// to simply use the default implementation.
+        /// </summary>
+        /// <value>The dependency resolver.</value>
+        public static IDependencyResolver Current {
+            get {
+                return unitTestDependencyResolver ?? dependencyResolver;
+            }
+            set {
+                if (ModeDetector.InUnitTestRunner()) {
+                    unitTestDependencyResolver = value;
+                    dependencyResolver = dependencyResolver ?? value;
+                } else {
+                    dependencyResolver = value;
+                }
+
+                var currentCallbacks = default(Action[]);
+                lock (resolverChanged) {
+                    // NB: Prevent deadlocks should we reenter this setter from 
+                    // the callbacks
+                    currentCallbacks = resolverChanged.ToArray();
+                }
+
+                foreach (var block in currentCallbacks) block();
+            }
+        }
+
+        /// <summary>
+        /// Convenience property to return the DependencyResolver cast to a
+        /// MutableDependencyResolver. The default resolver is also a mutable
+        /// resolver, so this will be non-null. Use this to register new types
+        /// on startup if you are using the default resolver
+        /// </summary>
+        public static IMutableDependencyResolver CurrentMutable {
+            get { return Current as IMutableDependencyResolver; }
+            set { Current = value; }
+        }
+
+        /// <summary>
+        /// This method allows libraries to register themselves to be set up
+        /// whenever the dependency resolver changes. Applications should avoid
+        /// this method, it is usually used for libraries that depend on service
+        /// location.
+        /// </summary>
+        /// <param name="callback">A callback that is invoked when the 
+        /// resolver is changed. This callback is also invoked immediately,
+        /// to configure the current resolver.</param>
+        /// <returns>When disposed, removes the callback. You probably can 
+        /// ignore this.</returns>
+        public static IDisposable RegisterResolverCallbackChanged(Action callback)
+        {
+            lock (resolverChanged) {
+                resolverChanged.Add(callback);
+            }
+
+            // NB: We always immediately invoke the callback to set up the 
+            // current resolver with whatever we've got
+            callback();
+
+            return new ActionDisposable(() => {
+                lock (resolverChanged) resolverChanged.Remove(callback);
+            });
+        }
+    }
+
+    /// <summary>
+    /// Represents a dependency resolver, a service to look up global class 
+    /// instances or types.
+    /// </summary>
+    public interface IDependencyResolver : IDisposable
+    {
+        /// <summary>
+        /// Gets an instance of the given <paramref name="serviceType"/>. Must return <c>null</c>
+        /// if the service is not available (must not throw).
+        /// </summary>
+        /// <param name="serviceType">The object type.</param>
+        /// <returns>The requested object, if found; <c>null</c> otherwise.</returns>
+        object GetService(Type serviceType, string contract = null);
+
+        /// <summary>
+        /// Gets all instances of the given <paramref name="serviceType"/>. Must return an empty
+        /// collection if the service is not available (must not return <c>null</c> or throw).
+        /// </summary>
+        /// <param name="serviceType">The object type.</param>
+        /// <returns>A sequence of instances of the requested <paramref name="serviceType"/>. The sequence
+        /// should be empty (not <c>null</c>) if no objects of the given type are available.</returns>
+        IEnumerable<object> GetServices(Type serviceType, string contract = null);
+    }
+
+    /// <summary>
+    /// Represents a dependency resolver where types can be registered after 
+    /// setup.
+    /// </summary>
+    public interface IMutableDependencyResolver : IDependencyResolver
+    {
+        void Register(Func<object> factory, Type serviceType, string contract = null);
+
+        /// <summary>
+        /// Register a callback to be called when a new service matching the type 
+        /// and contract is registered.
+        /// 
+        /// When registered, the callback is also called for each currently matching 
+        /// service.
+        /// </summary>
+        /// <returns>When disposed removes the callback</returns>
+        /// <param name="serviceType">Service type.</param>
+        /// <param name="contract">Contract.</param>
+        /// <param name="callback">Callback.</param>
+        IDisposable ServiceRegistrationCallback(Type serviceType, string contract, Action<IDisposable> callback);
+    }
+
+    public static class DependencyResolverMixins
+    {
+        /// <summary>
+        /// Gets an instance of the given <paramref name="serviceType"/>. Must return <c>null</c>
+        /// if the service is not available (must not throw).
+        /// </summary>
+        /// <param name="serviceType">The object type.</param>
+        /// <returns>The requested object, if found; <c>null</c> otherwise.</returns>
+        public static T GetService<T>(this IDependencyResolver This, string contract = null)
+        {
+            return (T)This.GetService(typeof(T), contract);
+        }
+
+        /// <summary>
+        /// Gets all instances of the given <paramref name="serviceType"/>. Must return an empty
+        /// collection if the service is not available (must not return <c>null</c> or throw).
+        /// </summary>
+        /// <param name="serviceType">The object type.</param>
+        /// <returns>A sequence of instances of the requested <paramref name="serviceType"/>. The sequence
+        /// should be empty (not <c>null</c>) if no objects of the given type are available.</returns>
+        public static IEnumerable<T> GetServices<T>(this IDependencyResolver This, string contract = null)
+        {
+            return This.GetServices(typeof(T), contract).Cast<T>();
+        }
+
+        public static IDisposable ServiceRegistrationCallback(this IMutableDependencyResolver This, Type serviceType, Action<IDisposable> callback)
+        {
+            return This.ServiceRegistrationCallback(serviceType, null, callback);
+        }
+
+        /// <summary>
+        /// Override the default Dependency Resolver until the object returned 
+        /// is disposed.
+        /// </summary>
+        /// <param name="resolver">The test resolver to use.</param>
+        public static IDisposable WithResolver(this IDependencyResolver resolver)
+        {
+            var origResolver = Locator.Current;
+            Locator.Current = resolver;
+
+            return new ActionDisposable(() => Locator.Current = origResolver);
+        }
+                
+        public static void RegisterConstant(this IMutableDependencyResolver This, object value, Type serviceType, string contract = null)
+        {
+            This.Register(() => value, serviceType, contract);
+        }
+
+        public static void RegisterLazySingleton(this IMutableDependencyResolver This, Func<object> valueFactory, Type serviceType, string contract = null)
+        {
+            var val = new Lazy<object>(valueFactory, LazyThreadSafetyMode.ExecutionAndPublication);
+            This.Register(() => val.Value, serviceType, contract);
+        }
+
+        public static void InitializeSplat(this IMutableDependencyResolver This)
+        {
+            This.Register(() => new DefaultLogManager(), typeof(ILogManager));
+            This.Register(() => new DebugLogger(), typeof(ILogger));
+        }
+    }
+
+    /// <summary>
+    /// This class is a dependency resolver written for modern C# 5.0 times. 
+    /// It implements all registrations via a Factory method. With the power
+    /// of Closures, you can actually implement most lifetime styles (i.e.
+    /// construct per call, lazy construct, singleton) using this.
+    ///
+    /// Unless you have a very compelling reason not to, this is the only class
+    /// you need in order to do dependency resolution, don't bother with using
+    /// a full IoC container.
+    /// </summary>
+    public class ModernDependencyResolver : IMutableDependencyResolver
+    {
+        Dictionary<Tuple<Type, string>, List<Func<object>>> _registry;
+        Dictionary<Tuple<Type, string>, List<Action<IDisposable>>> _callbackRegistry;
+
+        public ModernDependencyResolver() : this(null) { }
+
+        protected ModernDependencyResolver(Dictionary<Tuple<Type, string>, List<Func<object>>> registry)
+        {
+            _registry = registry != null ? 
+                registry.ToDictionary(k => k.Key, v => v.Value.ToList()) :
+                new Dictionary<Tuple<Type, string>, List<Func<object>>>();
+
+            _callbackRegistry = new Dictionary<Tuple<Type, string>, List<Action<IDisposable>>>();
+        }
+
+        public void Register(Func<object> factory, Type serviceType, string contract = null)
+        {
+            var pair = Tuple.Create(serviceType, contract ?? string.Empty);
+            if (!_registry.ContainsKey(pair)) {
+                _registry[pair] = new List<Func<object>>();
+            }
+
+            _registry[pair].Add(factory);
+
+            if (_callbackRegistry.ContainsKey(pair)) {
+                List<Action<IDisposable>> toRemove = null;
+
+                foreach (var callback in _callbackRegistry[pair]) {
+                    var remove = false;
+                    var disp = new ActionDisposable(() => {
+                        remove = true;
+                    });
+
+                    callback(disp);
+
+                    if (remove) {
+                        if (toRemove == null) {
+                            toRemove = new List<Action<IDisposable>>();
+                        }
+
+                        toRemove.Add(callback);
+                    }
+                }
+
+                if (toRemove != null) {
+                    foreach (var c in toRemove) {
+                        _callbackRegistry[pair].Remove(c);
+                    }
+                }
+            }
+        }
+
+        public object GetService(Type serviceType, string contract = null)
+        {
+            var pair = Tuple.Create(serviceType, contract ?? string.Empty);
+            if (!_registry.ContainsKey(pair)) return default(object);
+
+            var ret = _registry[pair].Last();
+            return ret();
+        }
+
+        public IEnumerable<object> GetServices(Type serviceType, string contract = null)
+        {
+            var pair = Tuple.Create(serviceType, contract ?? string.Empty);
+            if (!_registry.ContainsKey(pair)) return Enumerable.Empty<object>();
+
+            return _registry[pair].Select(x => x()).ToList();
+        }
+
+        public IDisposable ServiceRegistrationCallback(Type serviceType, string contract, Action<IDisposable> callback)
+        {
+            var pair = Tuple.Create(serviceType, contract ?? string.Empty);
+
+            if (!_callbackRegistry.ContainsKey(pair)) {
+                _callbackRegistry[pair] = new List<Action<IDisposable>>();
+            }
+
+            _callbackRegistry[pair].Add(callback);
+
+            var disp = new ActionDisposable(() => {
+                _callbackRegistry[pair].Remove(callback);
+            });
+
+            if (_registry.ContainsKey(pair)) {
+                foreach (var s in _registry[pair]) {
+                    callback(disp);
+                }
+            }
+
+            return disp;
+        }
+
+        public ModernDependencyResolver Duplicate()
+        {
+            return new ModernDependencyResolver(_registry);
+        }
+
+        public void Dispose()
+        {
+            _registry = null;
+        }
+    }
+
+    /// <summary>
+    /// A simple dependency resolver which takes Funcs for all its actions.
+    /// GetService is always implemented via GetServices().LastOrDefault()
+    /// </summary>
+    public class FuncDependencyResolver : IMutableDependencyResolver
+    {
+        readonly Func<Type, string, IEnumerable<object>> innerGetServices;
+        readonly Action<Func<object>, Type, string> innerRegister;
+        readonly Dictionary<Tuple<Type, string>, List<Action<IDisposable>>> _callbackRegistry = 
+            new Dictionary<Tuple<Type, string>, List<Action<IDisposable>>>();
+
+        IDisposable inner;
+
+        public FuncDependencyResolver(
+            Func<Type, string, IEnumerable<object>> getAllServices, 
+            Action<Func<object>, Type, string> register = null, 
+            IDisposable toDispose = null)
+        {
+            innerGetServices = getAllServices;
+            innerRegister = register;
+            inner = toDispose ?? ActionDisposable.Empty;
+        }
+
+        public object GetService(Type serviceType, string contract = null)
+        {
+            return (GetServices(serviceType, contract) ?? Enumerable.Empty<object>()).LastOrDefault();
+        }
+
+        public IEnumerable<object> GetServices(Type serviceType, string contract = null)
+        {
+            return innerGetServices(serviceType, contract);
+        }
+
+        public void Dispose() 
+        { 
+            Interlocked.Exchange(ref inner, ActionDisposable.Empty).Dispose();
+        }
+
+        public void Register(Func<object> factory, Type serviceType, string contract = null)
+        {
+            if (innerRegister == null) throw new NotImplementedException();
+            innerRegister(factory, serviceType, contract);
+
+            var pair = Tuple.Create(serviceType, contract ?? string.Empty);
+
+            if (_callbackRegistry.ContainsKey(pair)) {
+                List<Action<IDisposable>> toRemove = null;
+
+                foreach (var callback in _callbackRegistry[pair]) {
+                    var remove = false;
+                    var disp = new ActionDisposable(() => {
+                        remove = true;
+                    });
+
+                    callback(disp);
+
+                    if (remove) {
+                        if (toRemove == null) {
+                            toRemove = new List<Action<IDisposable>>();
+                        }
+
+                        toRemove.Add(callback);
+                    }
+                }
+
+                if (toRemove != null) {
+                    foreach (var c in toRemove) {
+                        _callbackRegistry[pair].Remove(c);
+                    }
+                }
+            }
+        }
+
+        public IDisposable ServiceRegistrationCallback(Type serviceType, string contract, Action<IDisposable> callback)
+        {
+            var pair = Tuple.Create(serviceType, contract ?? string.Empty);
+
+            if (!_callbackRegistry.ContainsKey(pair)) {
+                _callbackRegistry[pair] = new List<Action<IDisposable>>();
+            }
+
+            _callbackRegistry[pair].Add(callback);
+
+            return new ActionDisposable(() => {
+                _callbackRegistry[pair].Remove(callback);
+            });
+        }
+    }
+
+    sealed class ActionDisposable : IDisposable
+    {
+        Action block;
+
+        public static IDisposable Empty {
+            get { return new ActionDisposable(() => {}); }
+        }
+
+        public ActionDisposable(Action block)
+        {
+            this.block = block;
+        }
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref block, () => {})();
+        }
+    }
+}

--- a/src/Squirrel/Squirrel.csproj
+++ b/src/Squirrel/Squirrel.csproj
@@ -17,13 +17,16 @@
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />
     <PackageReference Include="Mono.Cecil" Version="0.9.6.1" />
     <PackageReference Include="SharpCompress" Version="0.17.1.0" />
-    <PackageReference Include="Splat" Version="1.6.2.0" />
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
   </ItemGroup>
 
 </Project>

--- a/src/Squirrel/SquirrelAwareApp.cs
+++ b/src/Squirrel/SquirrelAwareApp.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Splat;
+using Squirrel.SimpleSplat;
 
 namespace Squirrel
 {

--- a/src/Squirrel/TrayHelper.cs
+++ b/src/Squirrel/TrayHelper.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Win32;
-using Splat;
+using Squirrel.SimpleSplat;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Squirrel/UpdateInfo.cs
+++ b/src/Squirrel/UpdateInfo.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Runtime.Serialization;
-using Splat;
+using Squirrel.SimpleSplat;
 
 namespace Squirrel
 {

--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -9,7 +9,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using NuGet;
-using Splat;
+using Squirrel.SimpleSplat;
 using System.Threading;
 using Squirrel.Shell;
 using Microsoft.Win32;

--- a/src/Squirrel/UpdateManager.CheckForUpdates.cs
+++ b/src/Squirrel/UpdateManager.CheckForUpdates.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
-using Splat;
+using Squirrel.SimpleSplat;
 
 namespace Squirrel
 {

--- a/src/Squirrel/UpdateManager.DownloadReleases.cs
+++ b/src/Squirrel/UpdateManager.DownloadReleases.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Splat;
+using Squirrel.SimpleSplat;
 
 namespace Squirrel
 {

--- a/src/Squirrel/UpdateManager.Factory.cs
+++ b/src/Squirrel/UpdateManager.Factory.cs
@@ -1,5 +1,4 @@
-﻿using Splat;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;

--- a/src/Squirrel/UpdateManager.InstallHelpers.cs
+++ b/src/Squirrel/UpdateManager.InstallHelpers.cs
@@ -9,8 +9,8 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Win32;
 using NuGet;
-using Splat;
 using System.Reflection;
+using Squirrel.SimpleSplat;
 
 namespace Squirrel
 {

--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -15,7 +15,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32;
 using NuGet;
-using Splat;
+using Squirrel.SimpleSplat;
 using Squirrel.Shell;
 
 namespace Squirrel

--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -10,7 +10,7 @@ using System.Security.AccessControl;
 using System.Security.Cryptography;
 using System.Security.Principal;
 using System.Threading;
-using Splat;
+using Squirrel.SimpleSplat;
 using System.Text;
 using System.Threading.Tasks;
 using System.Collections.Concurrent;

--- a/src/StubExecutable/StubExecutable.vcxproj
+++ b/src/StubExecutable/StubExecutable.vcxproj
@@ -23,9 +23,9 @@
     <ConfigurationType>Application</ConfigurationType>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>StubExecutable</RootNamespace>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/src/StubExecutable/StubExecutable.vcxproj
+++ b/src/StubExecutable/StubExecutable.vcxproj
@@ -23,9 +23,9 @@
     <ConfigurationType>Application</ConfigurationType>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>StubExecutable</RootNamespace>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/src/StubExecutable/StubExecutable.vcxproj.filters
+++ b/src/StubExecutable/StubExecutable.vcxproj.filters
@@ -15,9 +15,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <Text Include="ReadMe.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <ClInclude Include="stdafx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -34,6 +31,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="version.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="version.inl">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -63,10 +63,5 @@
     <Image Include="StubExecutable.ico">
       <Filter>Resource Files</Filter>
     </Image>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="version.inl">
-      <Filter>Header Files</Filter>
-    </None>
   </ItemGroup>
 </Project>

--- a/src/StubExecutable/StubExecutable.vcxproj.filters
+++ b/src/StubExecutable/StubExecutable.vcxproj.filters
@@ -14,6 +14,9 @@
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
   </ItemGroup>
+   <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">
       <Filter>Header Files</Filter>
@@ -31,9 +34,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="version.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="version.inl">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -63,5 +63,10 @@
     <Image Include="StubExecutable.ico">
       <Filter>Resource Files</Filter>
     </Image>
+  </ItemGroup>
+   <ItemGroup>
+    <None Include="version.inl">
+      <Filter>Header Files</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/SyncReleases/Program.cs
+++ b/src/SyncReleases/Program.cs
@@ -10,7 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Mono.Options;
 using Octokit;
-using Splat;
+using Squirrel.SimpleSplat;
 using Squirrel;
 using Squirrel.Json;
 
@@ -35,8 +35,8 @@ namespace SyncReleases
 
         async Task<int> main(string[] args)
         {
-            using (var logger = new SetupLogLogger(false) { Level = Splat.LogLevel.Info }) {
-                Splat.Locator.CurrentMutable.Register(() => logger, typeof(Splat.ILogger));
+            using (var logger = new SetupLogLogger(false) { Level = Squirrel.SimpleSplat.LogLevel.Info }) {
+                Squirrel.SimpleSplat.Locator.CurrentMutable.Register(() => logger, typeof(Squirrel.SimpleSplat.ILogger));
 
                 var releaseDir = default(string);
                 var repoUrl = default(string);
@@ -89,11 +89,11 @@ namespace SyncReleases
         }
     }
 
-    class SetupLogLogger : Splat.ILogger, IDisposable
+    class SetupLogLogger : Squirrel.SimpleSplat.ILogger, IDisposable
     {
         StreamWriter inner;
         readonly object gate = 42;
-        public Splat.LogLevel Level { get; set; }
+        public Squirrel.SimpleSplat.LogLevel Level { get; set; }
 
         public SetupLogLogger(bool saveInTemp)
         {
@@ -107,7 +107,7 @@ namespace SyncReleases
             inner = new StreamWriter(file, false, Encoding.UTF8);
         }
 
-        public void Write(string message, Splat.LogLevel logLevel)
+        public void Write(string message, LogLevel logLevel)
         {
             if (logLevel < Level) {
                 return;

--- a/src/SyncReleases/SyncReleases.csproj
+++ b/src/SyncReleases/SyncReleases.csproj
@@ -22,6 +22,10 @@
     <PackageReference Include="ILRepack" Version="1.26.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
+  </ItemGroup>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PostBuildEvent>

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -1,5 +1,5 @@
 ﻿using NuGet;
-using Splat;
+using Squirrel.SimpleSplat;
 using Squirrel.Json;
 using System;
 using System.Collections.Generic;
@@ -44,7 +44,7 @@ namespace Squirrel.Update
                 opt = new StartupOption(args);
             } catch (Exception ex) {
                 using (var logger = new SetupLogLogger(true, "OptionParsing") { Level = LogLevel.Info }) {
-                    Locator.CurrentMutable.Register(() => logger, typeof(Splat.ILogger));
+                    Locator.CurrentMutable.Register(() => logger, typeof(Squirrel.SimpleSplat.ILogger));
                     logger.Write($"Failed to parse command line options. {ex.Message}", LogLevel.Error);
                 }
                 throw;
@@ -55,7 +55,7 @@ namespace Squirrel.Update
             bool isUninstalling = opt.updateAction == UpdateAction.Uninstall;
 
             using (var logger = new SetupLogLogger(isUninstalling, opt.updateAction.ToString()) {Level = LogLevel.Info}) {
-                Locator.CurrentMutable.Register(() => logger, typeof (Splat.ILogger));
+                Locator.CurrentMutable.Register(() => logger, typeof (SimpleSplat.ILogger));
 
                 try {
                     return executeCommandLine(args);
@@ -805,11 +805,11 @@ namespace Squirrel.Update
         }
     }
 
-    class SetupLogLogger : Splat.ILogger, IDisposable
+    class SetupLogLogger : SimpleSplat.ILogger, IDisposable
     {
         TextWriter inner;
         readonly object gate = 42;
-        public Splat.LogLevel Level { get; set; }
+        public SimpleSplat.LogLevel Level { get; set; }
 
         public SetupLogLogger(bool saveInTemp, string commandSuffix = null)
         {

--- a/src/Update/Update-Mono.csproj
+++ b/src/Update/Update-Mono.csproj
@@ -23,12 +23,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Splat" Version="1.6.2.0" />
     <PackageReference Include="WpfAnimatedGif" Version="1.4.15.0" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="ILRepack" Version="1.26.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/Update/Update.csproj
+++ b/src/Update/Update.csproj
@@ -22,12 +22,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Splat" Version="1.6.2.0" />
     <PackageReference Include="WpfAnimatedGif" Version="1.4.15.0" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="ILRepack" Version="1.26.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/WriteZipToSetup/WriteZipToSetup.vcxproj
+++ b/src/WriteZipToSetup/WriteZipToSetup.vcxproj
@@ -15,9 +15,9 @@
     <ConfigurationType>Application</ConfigurationType>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WriteZipToSetup</RootNamespace>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/WriteZipToSetup/WriteZipToSetup.vcxproj
+++ b/src/WriteZipToSetup/WriteZipToSetup.vcxproj
@@ -15,9 +15,9 @@
     <ConfigurationType>Application</ConfigurationType>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WriteZipToSetup</RootNamespace>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/WriteZipToSetup/WriteZipToSetup.vcxproj.filters
+++ b/src/WriteZipToSetup/WriteZipToSetup.vcxproj.filters
@@ -15,9 +15,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <Text Include="ReadMe.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <ClInclude Include="stdafx.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/test/ApplyReleasesTests.cs
+++ b/test/ApplyReleasesTests.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet;
-using Splat;
+using Squirrel.SimpleSplat;
 using Squirrel;
 using Squirrel.Tests.TestHelpers;
 using Xunit;

--- a/test/DeltaPackageTests.cs
+++ b/test/DeltaPackageTests.cs
@@ -3,8 +3,8 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet;
-using Splat;
 using Squirrel;
+using Squirrel.SimpleSplat;
 using Squirrel.Tests.TestHelpers;
 using Xunit;
 

--- a/test/DownloadReleasesTests.cs
+++ b/test/DownloadReleasesTests.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
-using Splat;
+using Squirrel.SimpleSplat;
 using Squirrel.Tests.TestHelpers;
 using Xunit;
 

--- a/test/ReleasePackageTests.cs
+++ b/test/ReleasePackageTests.cs
@@ -9,7 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
-using Splat;
+using Squirrel.SimpleSplat;
 using Xunit;
 
 namespace Squirrel.Tests.Core

--- a/test/TestHelpers/IntegrationTestHelper.cs
+++ b/test/TestHelpers/IntegrationTestHelper.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Squirrel;
-using Splat;
+using Squirrel.SimpleSplat;
 using Xunit;
 using System.Text;
 using SharpCompress.Archives.Zip;

--- a/test/UtilityTests.cs
+++ b/test/UtilityTests.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
-using Splat;
+using Squirrel.SimpleSplat;
 using Squirrel;
 using Squirrel.Tests.TestHelpers;
 using Xunit;
@@ -22,7 +22,7 @@ namespace Squirrel.Tests.Core
                 Description = "It's Notepad",
             };
 
-            sl.SetAppUserModelId("org.paulbetts.test");
+            sl.SetAppUserModelId("org.anaïsbetts.test");
             var path = Path.GetFullPath(@".\test.lnk");
             sl.Save(path);
 

--- a/test/fixtures/SquirrelInstalledApp.nuspec
+++ b/test/fixtures/SquirrelInstalledApp.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <id>SquirrelInstalledApp</id>
         <version>0.1.0</version>
-        <authors>paul</authors>
+        <authors>Anaïs Betts</authors>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>My package description.</description>
     </metadata>


### PR DESCRIPTION
1. Take the 1.6.2 branch of [reactiveui/splat](https://github.com/reactiveui/splat/releases/tag/1.6.2)
2. Take the bare minimum required for Squirrel, change name space
3. Remove NuGet references to Splat
4. Correctly name things
5. Update to VS2019, Update GitVersioning

Tests ran 100% before and after this change.
