### PR TITLE
DOC: GitHubUpdateManager

### DIFF
--- a/docs/using/github.md
+++ b/docs/using/github.md
@@ -50,9 +50,9 @@ using System.Threading.Tasks;
 **`static async Task Main()`**
 
 ~~~cs
-using (var mgr = UpdateManager.GitHubUpdateManager("https://github.com/myuser/myapp"))
+using (var mgr = UpdateManager.GitHubUpdateManager("https://github.com/myuser/myapp").Result)
 {
-  await mgr.Result.UpdateApp();
+  await mgr.UpdateApp();
 }
 ~~~
 


### PR DESCRIPTION
Update example for GitHubUpdateManager

Move `Task.Result` into `using` so the `UpdateManager` is disposed instead of the `Task`
(throws error otherwise)

For working example see [here](https://github.com/Drachenhorn-Team/Drachenhorn/blob/master/Drachenhorn.Desktop/UserSettings/SquirrelManager.cs)