### PR TITLE
Fixups for Squirrel.Windows 2.0

### DIFF
--- a/src/Setup/Setup.vcxproj
+++ b/src/Setup/Setup.vcxproj
@@ -17,6 +17,7 @@
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <RootNamespace>Setup</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/Squirrel.nuspec
+++ b/src/Squirrel.nuspec
@@ -25,7 +25,6 @@
     <file src="Squirrel\bin\Release\NuGet.Squirrel.*" target="lib\Net45" />
     <file src="Squirrel\bin\Release\ICSharpCode.*" target="lib\Net45" />
     <file src="squirrel.windows.props" target="build" />
-    <file src="squirrel.windows.targets" target="build" />
     <file src="Setup\bin\Release\Setup.exe" target="tools" />
     <file src="WriteZipToSetup\bin\Release\WriteZipToSetup.exe" target="tools" />
     <file src="StubExecutable\bin\Release\StubExecutable.exe" target="tools" />

--- a/src/Squirrel/SimpleSplat/Logging.cs
+++ b/src/Squirrel/SimpleSplat/Logging.cs
@@ -102,7 +102,7 @@ namespace Squirrel.SimpleSplat
 
         public DefaultLogManager(IDependencyResolver dependencyResolver = null)
         {
-            dependencyResolver = dependencyResolver ?? Locator.Current;
+            dependencyResolver = dependencyResolver ?? SquirrelLocator.Current;
 
             loggerCache = new MemoizingMRUCache<Type, IFullLogger>((type, _) => {
                 var ret = dependencyResolver.GetService<ILogger>();
@@ -191,7 +191,7 @@ namespace Squirrel.SimpleSplat
             get {
                 if (suppressLogging) return nullLogger;
 
-                var factory = Locator.Current.GetService<ILogManager>();
+                var factory = SquirrelLocator.Current.GetService<ILogManager>();
                 if (factory == null) {
                     throw new Exception("ILogManager is null. This should never happen, your dependency resolver is broken");
                 }
@@ -207,7 +207,7 @@ namespace Squirrel.SimpleSplat
         {
             if (suppressLogging) return nullLogger;
 
-            var factory = Locator.Current.GetService<ILogManager>();
+            var factory = SquirrelLocator.Current.GetService<ILogManager>();
             if (factory == null) {
                 throw new Exception("ILogManager is null. This should never happen, your dependency resolver is broken");
             }

--- a/src/Squirrel/SimpleSplat/ServiceLocation.cs
+++ b/src/Squirrel/SimpleSplat/ServiceLocation.cs
@@ -5,21 +5,21 @@ using System.Threading;
 
 namespace Squirrel.SimpleSplat
 {
-    public static class Locator
+    public static class SquirrelLocator
     {
         [ThreadStatic] static IDependencyResolver unitTestDependencyResolver;
         static IDependencyResolver dependencyResolver;
 
         static readonly List<Action> resolverChanged = new List<Action>();
 
-        static Locator()
+        static SquirrelLocator()
         {
             var r = new ModernDependencyResolver();
             dependencyResolver = r;
 
             RegisterResolverCallbackChanged(() => {
-                if (Locator.CurrentMutable == null) return;
-                Locator.CurrentMutable.InitializeSplat();
+                if (SquirrelLocator.CurrentMutable == null) return;
+                SquirrelLocator.CurrentMutable.InitializeSplat();
             });
         }
 
@@ -175,10 +175,10 @@ namespace Squirrel.SimpleSplat
         /// <param name="resolver">The test resolver to use.</param>
         public static IDisposable WithResolver(this IDependencyResolver resolver)
         {
-            var origResolver = Locator.Current;
-            Locator.Current = resolver;
+            var origResolver = SquirrelLocator.Current;
+            SquirrelLocator.Current = resolver;
 
-            return new ActionDisposable(() => Locator.Current = origResolver);
+            return new ActionDisposable(() => SquirrelLocator.Current = origResolver);
         }
                 
         public static void RegisterConstant(this IMutableDependencyResolver This, object value, Type serviceType, string contract = null)

--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -673,7 +673,7 @@ namespace Squirrel
         static IFullLogger Log()
         {
             return logger ??
-                (logger = Locator.CurrentMutable.GetService<ILogManager>().GetLogger(typeof(Utility)));
+                (logger = SquirrelLocator.CurrentMutable.GetService<ILogManager>().GetLogger(typeof(Utility)));
         }
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]

--- a/src/StubExecutable/StubExecutable.vcxproj
+++ b/src/StubExecutable/StubExecutable.vcxproj
@@ -25,7 +25,7 @@
     <RootNamespace>StubExecutable</RootNamespace>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/src/StubExecutable/StubExecutable.vcxproj.filters
+++ b/src/StubExecutable/StubExecutable.vcxproj.filters
@@ -14,9 +14,6 @@
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
   </ItemGroup>
-   <ItemGroup>
-    <Text Include="ReadMe.txt" />
-  </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">
       <Filter>Header Files</Filter>
@@ -34,6 +31,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="version.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="version.inl">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -63,10 +63,5 @@
     <Image Include="StubExecutable.ico">
       <Filter>Resource Files</Filter>
     </Image>
-  </ItemGroup>
-   <ItemGroup>
-    <None Include="version.inl">
-      <Filter>Header Files</Filter>
-    </None>
   </ItemGroup>
 </Project>

--- a/src/SyncReleases/Program.cs
+++ b/src/SyncReleases/Program.cs
@@ -36,7 +36,7 @@ namespace SyncReleases
         async Task<int> main(string[] args)
         {
             using (var logger = new SetupLogLogger(false) { Level = Squirrel.SimpleSplat.LogLevel.Info }) {
-                Squirrel.SimpleSplat.Locator.CurrentMutable.Register(() => logger, typeof(Squirrel.SimpleSplat.ILogger));
+                Squirrel.SimpleSplat.SquirrelLocator.CurrentMutable.Register(() => logger, typeof(Squirrel.SimpleSplat.ILogger));
 
                 var releaseDir = default(string);
                 var repoUrl = default(string);

--- a/src/SyncReleases/SyncReleases.csproj
+++ b/src/SyncReleases/SyncReleases.csproj
@@ -22,15 +22,11 @@
     <PackageReference Include="ILRepack" Version="1.26.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
-  </ItemGroup>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PostBuildEvent>
       cd "$(TargetDir)"
-      "$(NuGetPackageRoot)ilrepack\1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) SharpCompress.dll Microsoft.Web.XmlTransform.dll Splat.dll Squirrel.dll Octokit.dll NuGet.Squirrel.dll
+      "$(NuGetPackageRoot)ilrepack\1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) SharpCompress.dll Microsoft.Web.XmlTransform.dll Squirrel.dll Octokit.dll NuGet.Squirrel.dll
       del "$(TargetFileName)"
       ren "$(TargetFileName).tmp" "$(TargetFileName)"
     </PostBuildEvent>

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -44,7 +44,7 @@ namespace Squirrel.Update
                 opt = new StartupOption(args);
             } catch (Exception ex) {
                 using (var logger = new SetupLogLogger(true, "OptionParsing") { Level = LogLevel.Info }) {
-                    Locator.CurrentMutable.Register(() => logger, typeof(Squirrel.SimpleSplat.ILogger));
+                    SquirrelLocator.CurrentMutable.Register(() => logger, typeof(Squirrel.SimpleSplat.ILogger));
                     logger.Write($"Failed to parse command line options. {ex.Message}", LogLevel.Error);
                 }
                 throw;
@@ -55,7 +55,7 @@ namespace Squirrel.Update
             bool isUninstalling = opt.updateAction == UpdateAction.Uninstall;
 
             using (var logger = new SetupLogLogger(isUninstalling, opt.updateAction.ToString()) {Level = LogLevel.Info}) {
-                Locator.CurrentMutable.Register(() => logger, typeof (SimpleSplat.ILogger));
+                SquirrelLocator.CurrentMutable.Register(() => logger, typeof (SimpleSplat.ILogger));
 
                 try {
                     return executeCommandLine(args);

--- a/src/Update/Update-Mono.csproj
+++ b/src/Update/Update-Mono.csproj
@@ -30,15 +30,11 @@
     <PackageReference Include="ILRepack" Version="1.26.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
-  </ItemGroup>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PostBuildEvent>
       cd "$(TargetDir)"
-      "$(NuGetPackageRoot)ilrepack\1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) Microsoft.Web.XmlTransform.dll Splat.dll DeltaCompressionDotNet.dll DeltaCompressionDotNet.MsDelta.dll Squirrel.dll NuGet.Squirrel.dll Mono.Cecil.dll SharpCompress.dll
+      "$(NuGetPackageRoot)ilrepack\1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) Microsoft.Web.XmlTransform.dll DeltaCompressionDotNet.dll DeltaCompressionDotNet.MsDelta.dll Squirrel.dll NuGet.Squirrel.dll Mono.Cecil.dll SharpCompress.dll
       del "$(TargetFileName)"
       ren "$(TargetFileName).tmp" "$(TargetFileName)"
     </PostBuildEvent>

--- a/src/Update/Update.csproj
+++ b/src/Update/Update.csproj
@@ -29,15 +29,11 @@
     <PackageReference Include="ILRepack" Version="1.26.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
-  </ItemGroup>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PostBuildEvent>
       cd "$(TargetDir)"
-      "$(NuGetPackageRoot)ilrepack\1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) WpfAnimatedGif.dll SharpCompress.dll Microsoft.Web.XmlTransform.dll Splat.dll DeltaCompressionDotNet.dll DeltaCompressionDotNet.MsDelta.dll Squirrel.dll NuGet.Squirrel.dll Mono.Cecil.dll
+      "$(NuGetPackageRoot)ilrepack\1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) WpfAnimatedGif.dll SharpCompress.dll Microsoft.Web.XmlTransform.dll DeltaCompressionDotNet.dll DeltaCompressionDotNet.MsDelta.dll Squirrel.dll NuGet.Squirrel.dll Mono.Cecil.dll
       del "$(TargetFileName)"
       ren "$(TargetFileName).tmp" "$(TargetFileName)"
     </PostBuildEvent>

--- a/src/WriteZipToSetup/WriteZipToSetup.vcxproj
+++ b/src/WriteZipToSetup/WriteZipToSetup.vcxproj
@@ -17,7 +17,7 @@
     <RootNamespace>WriteZipToSetup</RootNamespace>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/squirrel.windows.targets
+++ b/src/squirrel.windows.targets
@@ -1,5 +1,0 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="CopySquirrel" BeforeTargets="Build">
-    <Copy SourceFiles="$(SquirrelToolsPath)\Squirrel.exe" DestinationFiles="$(OutputPath)\..\Update.exe" SkipUnchangedFiles="true" />
-  </Target>
-</Project>


### PR DESCRIPTION
Creating a PR to prepare for Squirrel.Windows 2.0.0 which mostly merges #1578 but also fixes #1616. Since we're moving namespaces around, this is a breaking change but ideally this won't result in any _actual_ work for people.

## TODO:

- [x] Get the heckin' thing to build
- [x] Expose logging types in a better way since it's a public'ish API
- [x] Make sure the C# API changes don't break clients too horribly
- [x] Make sure that electron-winstaller can still build installers
- [x] Make sure that an update from a Squirrel.Windows 1.x installation doesn't explode
- [x] Verify that none of the SDK changes bork Windows 7 installers
- [x] Debug the CMD window showing up

/cc @shiftkey @robmen @jaybeavers @dennisameling 