### PR TITLE
Fix issue where exe files were not removed during uninstall.

### DIFF
--- a/src/Squirrel/SquirrelAwareExecutableDetector.cs
+++ b/src/Squirrel/SquirrelAwareExecutableDetector.cs
@@ -36,25 +36,26 @@ namespace Squirrel
         static int? GetAssemblySquirrelAwareVersion(string executable)
         {
             try {
-                var assembly = AssemblyDefinition.ReadAssembly(executable);
-                if (!assembly.HasCustomAttributes) return null;
+                using (var assembly = AssemblyDefinition.ReadAssembly(executable)) {
+                    if (!assembly.HasCustomAttributes) return null;
 
-                var attrs = assembly.CustomAttributes;
-                var attribute = attrs.FirstOrDefault(x => {
-                    if (x.AttributeType.FullName != typeof(AssemblyMetadataAttribute).FullName) return false;
-                    if (x.ConstructorArguments.Count != 2) return false;
-                    return x.ConstructorArguments[0].Value.ToString() == "SquirrelAwareVersion";
-                });
+                    var attrs = assembly.CustomAttributes;
+                    var attribute = attrs.FirstOrDefault(x => {
+                        if (x.AttributeType.FullName != typeof(AssemblyMetadataAttribute).FullName) return false;
+                        if (x.ConstructorArguments.Count != 2) return false;
+                        return x.ConstructorArguments[0].Value.ToString() == "SquirrelAwareVersion";
+                    });
 
-                if (attribute == null) return null;
+                    if (attribute == null) return null;
 
-                int result;
-                if (!Int32.TryParse(attribute.ConstructorArguments[1].Value.ToString(), NumberStyles.Integer, CultureInfo.CurrentCulture, out result)) {
-                    return null;
+                    int result;
+                    if (!Int32.TryParse(attribute.ConstructorArguments[1].Value.ToString(), NumberStyles.Integer, CultureInfo.CurrentCulture, out result)) {
+                        return null;
+                    }
+
+                    return result;
                 }
-
-                return result;
-            } 
+            }
             catch (FileLoadException) { return null; }
             catch (BadImageFormatException) { return null; }
         }


### PR DESCRIPTION
This error occurred due to a disposable resource not being disposed.

Tested with our application and the change resolves the issue of exe-files not being removed since version 2.0.0.

Fixes #1641 

Sidenote: there's still two files left after an uninstall, a ".dead"-file, and Update.exe as described in #1586, but if I understand correctly that is expected behavior?

