### PR TITLE
Added CLI flag to onlyUpdate shortcuts

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -122,7 +122,7 @@ namespace Squirrel.Update
                     UpdateSelf().Wait();
                     break;
                 case UpdateAction.Shortcut:
-                    Shortcut(opt.target, opt.shortcutArgs, opt.processStartArgs, opt.setupIcon);
+                    Shortcut(opt.target, opt.shortcutArgs, opt.processStartArgs, opt.setupIcon, opt.onlyUpdateShortcuts);
                     break;
                 case UpdateAction.Deshortcut:
                     Deshortcut(opt.target, opt.shortcutArgs);
@@ -422,7 +422,7 @@ namespace Squirrel.Update
             }
         }
 
-        public void Shortcut(string exeName, string shortcutArgs, string processStartArgs, string icon)
+        public void Shortcut(string exeName, string shortcutArgs, string processStartArgs, string icon, bool onlyUpdate)
         {
             if (String.IsNullOrWhiteSpace(exeName)) {
                 ShowHelp();
@@ -434,7 +434,7 @@ namespace Squirrel.Update
             var locations = parseShortcutLocations(shortcutArgs);
 
             using (var mgr = new UpdateManager("", appName)) {
-                mgr.CreateShortcutsForExecutable(exeName, locations ?? defaultLocations, false, processStartArgs, icon);
+                mgr.CreateShortcutsForExecutable(exeName, locations ?? defaultLocations, onlyUpdate, processStartArgs, icon);
             }
         }
 

--- a/src/Update/StartupOption.cs
+++ b/src/Update/StartupOption.cs
@@ -26,6 +26,7 @@ namespace Squirrel.Update
         internal bool noMsi { get; private set; } = (Environment.OSVersion.Platform != PlatformID.Win32NT);        // NB: WiX doesn't work under Mono / Wine
         internal bool packageAs64Bit { get; private set; } = false;
         internal bool noDelta { get; private set; } = false;
+        internal bool onlyUpdateShortcuts { get; private set; } = false;
                
         public StartupOption(string[] args) {
            optionSet = Parse(args);
@@ -66,6 +67,7 @@ namespace Squirrel.Update
                 { "no-delta", "Don't generate delta packages to save time", v => noDelta = true},
                 { "framework-version=", "Set the required .NET framework version, e.g. net461", v => frameworkVersion = v },
                 { "msi-win64", "Mark the MSI as 64-bit, which is useful in Enterprise deployment scenarios", _ => packageAs64Bit = true},
+                { "updateOnly", "Update shortcuts that already exist, rather than creating new ones", _ => onlyUpdateShortcuts = true},
             };
 
             opts.Parse(args);


### PR DESCRIPTION
By default, running with `--createShortcut` will create shortcuts in each specified location. Running it again after a user has explicitly deleted a shortcut will result in the shortcut being re-created. If the user has deleted one of these shortcuts, Squirrel should be able to optionally not recreate them in order to respect the user's decision to delete. Because the calculation of shortcut paths and details is handled within Squirrel, this should be handled by Squirrel itself rather than by Squirrel apps. 

`CreateShortcutsForExecutable` has an option to "onlyUpdate" shortcuts (i.e. skipping if the shortcut does not already exist), this change exposes this option to the CLI as a flag.

This is intended to resurrect #1368 which has gone out of date. 

This impacts the following issues: #1050, #831 and potentially enables a solution for multiple other shortcut related issues (see references in linked issues). 