### PR TITLE
Modernise

### DIFF
--- a/src/Setup/Setup.vcxproj
+++ b/src/Setup/Setup.vcxproj
@@ -14,10 +14,10 @@
     <ProjectGuid>{C1D40624-A484-438A-B846-052F321C89D1}</ProjectGuid>
     <ConfigurationType>Application</ConfigurationType>
     <Keyword>Win32Proj</Keyword>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <RootNamespace>Setup</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/Squirrel.nuspec
+++ b/src/Squirrel.nuspec
@@ -21,17 +21,17 @@
     <copyright>Copyright GitHub© 2017</copyright>
   </metadata>
   <files>
-    <file src="..\Build\Release\Net45\Squirrel.*" target="lib\Net45" />
-    <file src="..\Build\Release\Net45\NuGet.Squirrel.*" target="lib\Net45" />
-    <file src="..\Build\Release\Net45\ICSharpCode.*" target="lib\Net45" />
+    <file src="..\build\Release\net462\Squirrel.*" target="lib\net462" />
+    <file src="..\build\Release\net462\NuGet.Squirrel.*" target="lib\net462" />
+    <file src="..\build\Release\net462\ICSharpCode.*" target="lib\net462" />
     <file src="squirrel.windows.props" target="build" />
-    <file src="..\Build\Release\Win32\Setup.exe" target="tools" />
-    <file src="..\Build\Release\Win32\WriteZipToSetup.exe" target="tools" />
-    <file src="..\Build\Release\Win32\StubExecutable.exe" target="tools" />
-    <file src="..\Build\Release\Net45\Update.exe" target="tools\Squirrel.exe" />
-    <file src="..\Build\Release\Net45\Update-Mono.exe" target="tools\Squirrel-Mono.exe" />
-    <file src="..\Build\Release\Net45\Update.com" target="tools\Squirrel.com" />
-    <file src="..\Build\Release\Net45\SyncReleases.exe" target="tools" />
+    <file src="..\build\Release\Win32\Setup.exe" target="tools" />
+    <file src="..\build\Release\Win32\WriteZipToSetup.exe" target="tools" />
+    <file src="..\build\Release\Win32\StubExecutable.exe" target="tools" />
+    <file src="..\build\Release\net462\Update.exe" target="tools\Squirrel.exe" />
+    <file src="..\build\Release\net462\Update-Mono.exe" target="tools\Squirrel-Mono.exe" />
+    <file src="..\build\Release\net462\Update.com" target="tools\Squirrel.com" />
+    <file src="..\build\Release\net462\SyncReleases.exe" target="tools" />
     <file src="Update\signtool.exe" target="tools\signtool.exe" />
     <file src="Update\rcedit.exe" target="tools\rcedit.exe" />
     <file src="..\vendor\wix\*" target="tools" />

--- a/src/Squirrel/BinaryPatchUtility.cs
+++ b/src/Squirrel/BinaryPatchUtility.cs
@@ -113,7 +113,7 @@ namespace Squirrel.Bsdiff
             int eblen = 0;
 
             using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
-            using (var bz2Stream = new BZip2Stream(wrappingStream, CompressionMode.Compress))
+            using (var bz2Stream = new BZip2Stream(wrappingStream, CompressionMode.Compress, false))
             {
                 // compute the differences, writing ctrl as we go
                 int scan = 0;
@@ -231,7 +231,7 @@ namespace Squirrel.Bsdiff
 
             // write compressed diff data
             using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
-            using (var bz2Stream = new BZip2Stream(wrappingStream, CompressionMode.Compress))
+            using (var bz2Stream = new BZip2Stream(wrappingStream, CompressionMode.Compress, false))
             {
                 bz2Stream.Write(db, 0, dblen);
             }
@@ -242,7 +242,7 @@ namespace Squirrel.Bsdiff
 
             // write compressed extra data
             using (WrappingStream wrappingStream = new WrappingStream(output, Ownership.None))
-            using (var bz2Stream = new BZip2Stream(wrappingStream, CompressionMode.Compress))
+            using (var bz2Stream = new BZip2Stream(wrappingStream, CompressionMode.Compress, false))
             {
                 bz2Stream.Write(eb, 0, eblen);
             }
@@ -327,9 +327,9 @@ namespace Squirrel.Bsdiff
                 compressedExtraStream.Seek(c_headerSize + controlLength + diffLength, SeekOrigin.Current);
 
                 // decompress each part (to read it)
-                using (var controlStream = new BZip2Stream(compressedControlStream, CompressionMode.Decompress))
-                using (var diffStream = new BZip2Stream(compressedDiffStream, CompressionMode.Decompress))
-                using (var extraStream = new BZip2Stream(compressedExtraStream, CompressionMode.Decompress))
+                using (var controlStream = new BZip2Stream(compressedControlStream, CompressionMode.Decompress, false))
+                using (var diffStream = new BZip2Stream(compressedDiffStream, CompressionMode.Decompress, false))
+                using (var extraStream = new BZip2Stream(compressedExtraStream, CompressionMode.Decompress, false))
                 {
                     long[] control = new long[3];
                     byte[] buffer = new byte[8];

--- a/src/Squirrel/ReleasePackage.cs
+++ b/src/Squirrel/ReleasePackage.cs
@@ -178,13 +178,14 @@ namespace Squirrel
                         var fullTargetDir = Path.GetDirectoryName(fullTargetFile);
                         Directory.CreateDirectory(fullTargetDir);
 
-                        Utility.Retry(() => {
-                            if (reader.Entry.IsDirectory) {
-                                Directory.CreateDirectory(Path.Combine(outFolder, decoded));
-                            } else {
-                                reader.WriteEntryToFile(Path.Combine(outFolder, decoded));
-                            }
-                        }, 5);
+                        if (reader.Entry.IsDirectory)
+                        {
+                            Directory.CreateDirectory(Path.Combine(outFolder, decoded));
+                        }
+                        else
+                        {
+                            reader.WriteEntryToFile(Path.Combine(outFolder, decoded));
+                        }
                     }
                 }
             });
@@ -233,14 +234,16 @@ namespace Squirrel
                             LogHost.Default.Info("Rigging execution stub for {0} to {1}", decoded, fullTargetFile);
                         }
 
-                        try {
-                            Utility.Retry(() => {
-                                if (reader.Entry.IsDirectory) {
-                                    Directory.CreateDirectory(fullTargetFile);
-                                } else {
-                                    reader.WriteEntryToFile(fullTargetFile);
-                                }
-                            }, 5);
+                        try 
+                        {
+                            if (reader.Entry.IsDirectory)
+                            {
+                                Directory.CreateDirectory(fullTargetFile);
+                            }
+                            else
+                            {
+                                reader.WriteEntryToFile(fullTargetFile);
+                            }
                         } catch (Exception e) {
                             if (!failureIsOkay) throw;
                             LogHost.Default.WarnException("Can't write execution stub, probably in use", e);

--- a/src/Squirrel/Squirrel.csproj
+++ b/src/Squirrel/Squirrel.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <Description>Squirrel</Description>
     <Title>Squirrel</Title>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -13,10 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DeltaCompressionDotNet" Version="1.1.0.0" />
-    <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.1" />
-    <PackageReference Include="Mono.Cecil" Version="0.11.2" />
-    <PackageReference Include="SharpCompress" Version="0.17.1.0" />
+    <PackageReference Include="DeltaCompressionDotNet" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.3" />
+    <PackageReference Include="SharpCompress" Version="0.26.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.3.37" />
   </ItemGroup>
 
 </Project>

--- a/src/StubExecutable/StubExecutable.vcxproj
+++ b/src/StubExecutable/StubExecutable.vcxproj
@@ -23,9 +23,9 @@
     <ConfigurationType>Application</ConfigurationType>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>StubExecutable</RootNamespace>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/src/SyncReleases/SyncImplementations.cs
+++ b/src/SyncReleases/SyncImplementations.cs
@@ -50,13 +50,13 @@ namespace SyncReleases
             }
 
             var nwo = nwoFromRepoUrl(repoUrl);
-            var releases = (await client.Release.GetAll(nwo.Item1, nwo.Item2))
+            var releases = (await client.Repository.Release.GetAll(nwo.Item1, nwo.Item2))
                 .OrderByDescending(x => x.PublishedAt)
                 .Take(5);
 
             await releases.ForEachAsync(async release => {
                 // NB: Why do I have to double-fetch the release assets? It's already in GetAll
-                var assets = await client.Release.GetAllAssets(nwo.Item1, nwo.Item2, release.Id);
+                var assets = await client.Repository.Release.GetAllAssets(nwo.Item1, nwo.Item2, release.Id);
 
                 await assets
                     .Where(x => x.Name.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))

--- a/src/SyncReleases/SyncReleases.csproj
+++ b/src/SyncReleases/SyncReleases.csproj
@@ -3,7 +3,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Exe</OutputType>
     <Description>SyncReleases</Description>
     <Title>SyncReleases</Title>
@@ -15,24 +15,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="0.10.0.0" />
+    <PackageReference Include="Octokit" Version="0.48.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ILRepack" Version="1.26.0" PrivateAssets="All" />
+    <PackageReference Include="ILRepack" Version="2.0.18" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
+	  <PackageReference Update="Nerdbank.GitVersioning" Version="3.3.37" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PostBuildEvent>
-      cd "$(TargetDir)"
-      "$(NuGetPackageRoot)ilrepack\1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) SharpCompress.dll Microsoft.Web.XmlTransform.dll Squirrel.dll Octokit.dll NuGet.Squirrel.dll
-      del "$(TargetFileName)"
-      ren "$(TargetFileName).tmp" "$(TargetFileName)"
-    </PostBuildEvent>
+		cd "$(TargetDir)"
+		"$(NuGetPackageRoot)ilrepack\2.0.18\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) SharpCompress.dll System.Memory.dll System.Buffers.dll Microsoft.Web.XmlTransform.dll Squirrel.dll Octokit.dll NuGet.Squirrel.dll System.Runtime.CompilerServices.Unsafe.dll System.Numerics.Vectors.dll System.Spatial.dll
+		del "$(TargetFileName)"
+		ren "$(TargetFileName).tmp" "$(TargetFileName)"
+	</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/Update/Update-Mono.csproj
+++ b/src/Update/Update-Mono.csproj
@@ -3,7 +3,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Exe</OutputType>
     <Description>Update</Description>
     <Title>Update</Title>
@@ -23,25 +23,25 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WpfAnimatedGif" Version="1.4.15.0" />
+    <PackageReference Include="WpfAnimatedGif" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ILRepack" Version="1.26.0" PrivateAssets="All" />
+    <PackageReference Include="ILRepack" Version="2.0.18" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.3.37" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PostBuildEvent>
-      cd "$(TargetDir)"
-      "$(NuGetPackageRoot)ilrepack\1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) Microsoft.Web.XmlTransform.dll DeltaCompressionDotNet.dll DeltaCompressionDotNet.MsDelta.dll Squirrel.dll NuGet.Squirrel.dll Mono.Cecil.dll SharpCompress.dll
-      del "$(TargetFileName)"
-      ren "$(TargetFileName).tmp" "$(TargetFileName)"
-    </PostBuildEvent>
+		cd "$(TargetDir)"
+		"$(NuGetPackageRoot)ilrepack\2.0.18\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) Microsoft.Web.XmlTransform.dll DeltaCompressionDotNet.dll Squirrel.dll NuGet.Squirrel.dll Mono.Cecil.dll SharpCompress.dll System.Runtime.CompilerServices.Unsafe.dll System.Memory.dll System.Buffers.dll System.Numerics.Vectors.dll System.Spatial.dll
+		del "$(TargetFileName)"
+		ren "$(TargetFileName).tmp" "$(TargetFileName)"
+	</PostBuildEvent>
   </PropertyGroup>
 
 </Project>

--- a/src/Update/Update.csproj
+++ b/src/Update/Update.csproj
@@ -3,8 +3,8 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
-    <OutputType>WinExe</OutputType>
+    <TargetFramework>net462</TargetFramework>
+    <OutputType>Exe</OutputType>
     <Description>Update</Description>
     <Title>Update</Title>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -22,25 +22,31 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WpfAnimatedGif" Version="1.4.15.0" />
+    <PackageReference Include="WpfAnimatedGif" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ILRepack" Version="1.26.0" PrivateAssets="All" />
+    <PackageReference Include="ILRepack" Version="2.0.18" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.3.37" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PostBuildEvent>
-      cd "$(TargetDir)"
-      "$(NuGetPackageRoot)ilrepack\1.26.0\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) WpfAnimatedGif.dll SharpCompress.dll Microsoft.Web.XmlTransform.dll DeltaCompressionDotNet.dll DeltaCompressionDotNet.MsDelta.dll Squirrel.dll NuGet.Squirrel.dll Mono.Cecil.dll
-      del "$(TargetFileName)"
-      ren "$(TargetFileName).tmp" "$(TargetFileName)"
-    </PostBuildEvent>
+		cd "$(TargetDir)"
+		"$(NuGetPackageRoot)ilrepack\2.0.18\tools\ILRepack.exe" /internalize /out:$(TargetFileName).tmp $(TargetFileName) WpfAnimatedGif.dll SharpCompress.dll System.Memory.dll System.Buffers.dll System.Runtime.CompilerServices.Unsafe.dll Microsoft.Web.XmlTransform.dll DeltaCompressionDotNet.dll Squirrel.dll NuGet.Squirrel.dll Mono.Cecil.dll System.Numerics.Vectors.dll System.Spatial.dll
+		del "$(TargetFileName)"
+		ren "$(TargetFileName).tmp" "$(TargetFileName)"
+	</PostBuildEvent>
   </PropertyGroup>
 
 </Project>

--- a/src/WriteZipToSetup/WriteZipToSetup.vcxproj
+++ b/src/WriteZipToSetup/WriteZipToSetup.vcxproj
@@ -15,9 +15,9 @@
     <ConfigurationType>Application</ConfigurationType>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WriteZipToSetup</RootNamespace>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/test/Squirrel.Tests.csproj
+++ b/test/Squirrel.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <Description>Squirrel.Tests</Description>
     <Title>Squirrel.Tests</Title>
     <IsPackable>false</IsPackable>
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Target .net framework 4.6.2
* Update dependencies
* Build update.exe as Exe rather than WindowsExe so we actually get console output

I saw the problems you had earlier with updating SharpCompress. Maybe the move to .net framework 4.6.2 fixes this. I had no issues updating my installation with this version