### PR TITLE
Enhancement to support --installationPath when running setup.exe.

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -103,7 +103,7 @@ namespace Squirrel.Update
                         AnimatedGifWindow.ShowWindow(TimeSpan.FromSeconds(4), animatedGifWindowToken.Token, progressSource);
                     }
 
-                    Install(opt.silentInstall, progressSource, Path.GetFullPath(opt.target)).Wait();
+                    Install(opt.silentInstall, progressSource, Path.GetFullPath(opt.target), opt.installationPath).Wait();
                     animatedGifWindowToken.Cancel();
                     break;
                 case UpdateAction.Uninstall:
@@ -140,7 +140,7 @@ namespace Squirrel.Update
             return 0;
         }
 
-        public async Task Install(bool silentInstall, ProgressSource progressSource, string sourceDirectory = null)
+        public async Task Install(bool silentInstall, ProgressSource progressSource, string sourceDirectory = null, string installationPath = null)
         {
             sourceDirectory = sourceDirectory ?? Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var releasesPath = Path.Combine(sourceDirectory, "RELEASES");
@@ -159,7 +159,7 @@ namespace Squirrel.Update
             var ourAppName = ReleaseEntry.ParseReleaseFile(File.ReadAllText(releasesPath, Encoding.UTF8))
                 .First().PackageName;
 
-            using (var mgr = new UpdateManager(sourceDirectory, ourAppName)) {
+            using (var mgr = new UpdateManager(sourceDirectory, ourAppName, installationPath)) {
                 this.Log().Info("About to install to: " + mgr.RootAppDirectory);
                 if (Directory.Exists(mgr.RootAppDirectory)) {
                     this.Log().Warn("Install path {0} already exists, burning it to the ground", mgr.RootAppDirectory);

--- a/src/Update/StartupOption.cs
+++ b/src/Update/StartupOption.cs
@@ -20,6 +20,7 @@ namespace Squirrel.Update
         internal string processStartArgs { get; private set; } = default(string);
         internal string setupIcon { get; private set; } = default(string);
         internal string icon { get; private set; } = default(string);
+        internal string installationPath { get; private set; } = default(string);
         internal string shortcutArgs { get; private set; } = default(string);
         internal string frameworkVersion { get; private set; } = "net45";
         internal bool shouldWait { get; private set; } = false;
@@ -57,6 +58,7 @@ namespace Squirrel.Update
                 { "bootstrapperExe=", "Path to the Setup.exe to use as a template", v => bootstrapperExe = v},
                 { "g=|loadingGif=", "Path to an animated GIF to be displayed during installation", v => backgroundGif = v},
                 { "i=|icon", "Path to an ICO file that will be used for icon shortcuts", v => icon = v},
+                { "installationPath=|iPath", "Path to where application is going to be installed.", v => installationPath = v},
                 { "setupIcon=", "Path to an ICO file that will be used for the Setup executable's icon", v => setupIcon = v},
                 { "n=|signWithParams=", "Sign the installer via SignTool.exe with the parameters given", v => signingParameters = v},
                 { "s|silent", "Silent install", _ => silentInstall = true},


### PR DESCRIPTION
This is to fix: #1002 .

Sometimes for enterprise installations there is no other option than setting the installation path.

**Example:**
setup.exe --installationPath "C:\tmp"