### PR TITLE
Do not modify TaskBar icons with a similar application directory

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -24,7 +24,7 @@ namespace Squirrel
 
             public ApplyReleasesImpl(string rootAppDirectory)
             {
-                this.rootAppDirectory = rootAppDirectory;
+                this.rootAppDirectory = rootAppDirectory.EndsWith("\\") ? rootAppDirectory : rootAppDirectory + "\\";
             }
 
             public async Task<string> ApplyReleases(UpdateInfo updateInfo, bool silentInstall, bool attemptingFullInstall, Action<int> progress = null)


### PR DESCRIPTION
When this program runs, it loops over all the symlinks created in the
user's TaskBar in an attempt to update the symlinks corresponding to the
application being installed.

The logic goes like this:

```
if (!shortcut.Target.StartsWith(rootAppDirectory, StringComparison.OrdinalIgnoreCase)) continue;
```

Now consider two applications where the application root directory of
the first starts with the application root directory of the second:

- `C:\\Users\\jv\\AppData\\Local\\Postman\\Postman.exe`
- `C:\\Users\\jv\\AppData\\Local\\PostmanCanary\\PostmanCanary.exe`

When running Squirrel for the first application, Squirrel will
incorrectly update and break the TaskBar symlink pointing to
`C:\\Users\\jv\\AppData\\Local\\PostmanCanary\\PostmanCanary.exe` as
`C:\\Users\\jv\\AppData\\Local\\PostmanCanary` starts with
`C:\\Users\\jv\\AppData\\Local\\Postman` from a string point of view.

This commit ensures that we only modify TaskBar symlinks with the same
application directory, ignoring other application directories that share
the same prefix string.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>