### PR TITLE
Remove `removeDeveloperDocumentation`

### DIFF
--- a/src/Squirrel/ReleasePackage.cs
+++ b/src/Squirrel/ReleasePackage.cs
@@ -148,7 +148,6 @@ namespace Squirrel
 
                 this.Log().Info("Removing unnecessary data");
                 removeDependenciesFromPackageSpec(specPath);
-                removeDeveloperDocumentation(tempDir);
 
                 if (releaseNotesProcessor != null) {
                     renderReleaseNotesMarkdown(specPath, releaseNotesProcessor);
@@ -274,15 +273,6 @@ namespace Squirrel
                     }
                 });
             });
-        }
-
-        void removeDeveloperDocumentation(DirectoryInfo expandedRepoPath)
-        {
-            expandedRepoPath.GetAllFilesRecursively()
-                .Where(x => x.Name.EndsWith(".dll", true, CultureInfo.InvariantCulture))
-                .Select(x => new FileInfo(x.FullName.ToLowerInvariant().Replace(".dll", ".xml")))
-                .Where(x => x.Exists)
-                .ForEach(x => x.Delete());
         }
 
         void renderReleaseNotesMarkdown(string specPath, Func<string, string> releaseNotesProcessor)


### PR DESCRIPTION
Stop removing xml files from the package generated by releasify. 

As discussed here: https://github.com/Squirrel/Squirrel.Windows/issues/1323#issuecomment-398785976, in some cases these xml files are necessary. If they aren't, they can be excluded from the package in the csproj or nuspec file.