### PR TITLE
Update and consolidate NB.GV refs

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <ItemGroup Condition=" '$(MSBuildProjectExtension)'=='.csproj' ">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.65" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.240" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(MSBuildProjectExtension)'=='.vcxproj' ">

--- a/src/Squirrel/Squirrel.csproj
+++ b/src/Squirrel/Squirrel.csproj
@@ -25,8 +25,4 @@
     <Reference Include="System.Web" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
-  </ItemGroup>
-
 </Project>

--- a/src/SyncReleases/SyncReleases.csproj
+++ b/src/SyncReleases/SyncReleases.csproj
@@ -22,10 +22,6 @@
     <PackageReference Include="ILRepack" Version="1.26.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
-  </ItemGroup>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PostBuildEvent>

--- a/src/Update/Update-Mono.csproj
+++ b/src/Update/Update-Mono.csproj
@@ -30,10 +30,6 @@
     <PackageReference Include="ILRepack" Version="1.26.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
-  </ItemGroup>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PostBuildEvent>

--- a/src/Update/Update.csproj
+++ b/src/Update/Update.csproj
@@ -29,10 +29,6 @@
     <PackageReference Include="ILRepack" Version="1.26.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.0.50" />
-  </ItemGroup>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PostBuildEvent>


### PR DESCRIPTION
An old NB.GV was referenced everywhere via Directory.Build.props file. Newer ones were updated in specific projects, although I don't know why the root level one was not updated instead.
This change removes all the Update elements in favor of updating the one root-level one.