### PR TITLE
Fix debug build of Setup

### DIFF
--- a/src/Setup/Setup.vcxproj
+++ b/src/Setup/Setup.vcxproj
@@ -22,7 +22,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <UseOfMfc>Static</UseOfMfc>
+    <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>


### PR DESCRIPTION
The Setup.vcxproj file had an option for Debug builds that it would use MFC. However, the release builds didn't have that option, and compiling doesn't require it, so this change removes the MFC requirement which will allow to build without MFC installed.