### PR TITLE
Show signtool output on error

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -596,6 +596,8 @@ namespace Squirrel.Update
                 String.Format("sign {0} \"{1}\"", signingOpts, exePath), CancellationToken.None);
 
             if (processResult.Item1 != 0) {
+                Console.WriteLine("signtool failed. output:");
+                Console.WriteLine(processResult.Item2);
                 var optsWithPasswordHidden = new Regex(@"/p\s+\w+").Replace(signingOpts, "/p ********");
                 var msg = String.Format("Failed to sign, command invoked was: '{0} sign {1} {2}'",
                     exe, optsWithPasswordHidden, exePath);


### PR DESCRIPTION
The signtool output is captured but only displayed in the event of success. This makes it hard to identify the causes of signtool problems, especially since signtool is operating on files in a temp location which are cleaned up after failure. Adding output of the signtool output on error helped me identify the cause of a problem I had when trying to releasify.

Thank you, Squirrel team!