### PR TITLE
Fix 'debug mode' pathToWixTools

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -744,8 +744,8 @@ namespace Squirrel.Update
             }
 
             // Debug Mode (i.e. in vendor)
-            var debugPath = Path.Combine(ourPath, "..", "..", "..", "vendor", "wix", "candle.exe");
-            if (File.Exists(debugPath)) {
+            var debugPath = Path.Combine(ourPath, "..", "..", "..", "vendor", "wix");
+            if (File.Exists(Path.Combine(debugPath, "candle.exe"))) {
                 return Path.GetFullPath(debugPath);
             }
 


### PR DESCRIPTION
The "debug mode" search for `candle.exe` in `pathToWixTools` causes the method to return the full path of the `candle.exe` while the other search returns the path of the folder containing `candle.exe`.

Prior to this PR it results in attempts to use `vendor\wix\candle.exe\template.wxs` rather than `vendor\wix\template.wxs`.

Thank you, Squirrel team! (This is the last of the PRs I have planned. They seemed unrelated enough to be inappropriate to pack together into a single PR. Thanks!)