### PR TITLE
TLS 1.3 support

### DIFF
--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -104,8 +104,15 @@ namespace Squirrel
 
         public static WebClient CreateWebClient()
         {
-            // WHY DOESNT IT JUST DO THISSSSSSSS
-            System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+            // enable TLS support
+            // TLS 1.0 and 1.1 are enabled for backward compatibility and should be disabled in the future
+            // for security reasons
+            ServicePointManager.SecurityProtocol |=
+                SecurityProtocolType.Tls12 |
+                SecurityProtocolType.Tls11 |
+                SecurityProtocolType.Tls;
+            // disable SSLv3 support for security reasons
+            ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Ssl3;
 
             var ret = new WebClient();
             var wp = WebRequest.DefaultWebProxy;


### PR DESCRIPTION
Hard setting the security protocols in the ServicePointManager disallows the usage of newer security protocols for the update source.
Enabling TLS 1.3 support in the app using Squirrel should now work as intended and not be overwritten whenever a web client is created.