### PR TITLE
Fix app can not restart after an unexpected exit during the apply releases

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -320,9 +320,9 @@ namespace Squirrel
                         progressCallback);
 
                     // Delete the .not-finished file after extraction is completed
-                    if (File.Exists(notFinishedFilePath)) {
+                    this.ErrorIfThrows(() => {
                         File.Delete(notFinishedFilePath);
-                    }
+                    }, "Couldn't delete file: " + notFinishedFilePath);
 
                     return target.FullName;
                 });

--- a/src/StubExecutable/StubExecutable.cpp
+++ b/src/StubExecutable/StubExecutable.cpp
@@ -74,10 +74,10 @@ std::wstring FindLatestAppDir()
 
 		// Skip the directory which contains a .not-finished file
 		std::wstring appFolder = fileInfo.cFileName;
-        std::wstring dirPath = ourDir.substr(0, ourDir.size() - 5) + appFolder;
-        if (FileExists(dirPath + L"\\.not-finished")) {
-            continue;
-        }
+		std::wstring dirPath = ourDir.substr(0, ourDir.size() - 5) + appFolder;
+		if (FileExists(dirPath + L"\\.not-finished")) {
+			continue;
+		}
 
 		if (thisVer > acc) {
 			acc = thisVer;

--- a/src/StubExecutable/StubExecutable.cpp
+++ b/src/StubExecutable/StubExecutable.cpp
@@ -8,6 +8,11 @@
 
 using namespace std;
 
+bool FileExists(const std::wstring& filePath) {
+    DWORD fileAttributes = GetFileAttributes(filePath.c_str());
+    return (fileAttributes != INVALID_FILE_ATTRIBUTES) && !(fileAttributes & FILE_ATTRIBUTE_DIRECTORY);
+}
+
 wchar_t* FindRootAppDir() 
 {
 	wchar_t* ourDirectory = new wchar_t[MAX_PATH];
@@ -66,6 +71,13 @@ std::wstring FindLatestAppDir()
 		std::string s(appVer.begin(), appVer.end());
 
 		version::Semver200_version thisVer(s);
+
+		// Skip the directory which contains a .not-finished file
+		std::wstring appFolder = fileInfo.cFileName;
+        std::wstring dirPath = ourDir.substr(0, ourDir.size() - 5) + appFolder;
+        if (FileExists(dirPath + L"\\.not-finished")) {
+            continue;
+        }
 
 		if (thisVer > acc) {
 			acc = thisVer;


### PR DESCRIPTION
Problem Description: During the use of Squirrel's automatic upgrade feature, if the app is quit or unexpectedly exits while installing the new version, it may result in unable to restart the app. Upon reviewing the source code, it was found that the stubExe would find the latest version and create the path to launch it. However, due to missing files in the latest app-xxx directory, the app fails to start.

Solution: To address this issue, during the application of releases, the new version is first extracted to a temp-app-xxxx directory. After the extraction is complete, it is then renamed to the final app-xxxx directory. This approach ensures that even if the app unexpectedly exits during the installation process and leaves the temp directory, it will not affect the next app launch.