### PR TITLE
Allow running as admin in Wine

### DIFF
--- a/src/Setup/UpdateRunner.cpp
+++ b/src/Setup/UpdateRunner.cpp
@@ -34,6 +34,20 @@ void CUpdateRunner::DisplayErrorMessage(CString& errorMessage, wchar_t* logFile)
 	}
 }
 
+HRESULT CUpdateRunner::AreWeInWine()
+{
+	// NB: Behaving differently in Wine is *usually* discouraged
+	// https://wiki.winehq.org/Developer_FAQ#How_can_I_detect_Wine.3F
+	HMODULE hntdll = GetModuleHandle(L"ntdll.dll");
+	if (!hntdll) {
+		return S_FALSE;
+	}
+	if (!GetProcAddress(hntdll, L"wine_get_version")) {
+		return S_FALSE;
+	}
+	return S_OK;
+}
+
 HRESULT CUpdateRunner::AreWeUACElevated()
 {
 	HANDLE hProcess = GetCurrentProcess();

--- a/src/Setup/UpdateRunner.h
+++ b/src/Setup/UpdateRunner.h
@@ -4,6 +4,7 @@ class CUpdateRunner
 
 public:
 	static void DisplayErrorMessage(CString& errorMessage, wchar_t* logFile);
+	static HRESULT AreWeInWine();
 	static HRESULT AreWeUACElevated();
 	static HRESULT ShellExecuteFromExplorer(LPWSTR pszFile, LPWSTR pszParameters);
 	static bool DirectoryExists(wchar_t* szPath);

--- a/src/Setup/winmain.cpp
+++ b/src/Setup/winmain.cpp
@@ -110,7 +110,8 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 
 	// If we're UAC-elevated, we shouldn't be because it will give us permissions
 	// problems later. Just silently rerun ourselves.
-	if (weAreUACElevated) {
+	// (Skip this check in Wine, which always reports admin privileges)
+	if (weAreUACElevated && CUpdateRunner::AreWeInWine() != S_OK) {
 		wchar_t buf[4096];
 		HMODULE hMod = GetModuleHandle(NULL);
 		GetModuleFileNameW(hMod, buf, 4096);


### PR DESCRIPTION
The admin privileges check introduced in #254 prevents working at all in Wine, which always reports admin privileges. Since there's no danger of causing permissions problems in that environment, allow it as a special case.

Hopefully closes #1720.