### PR TITLE
Create shortcuts directly in the Start Menu

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -735,7 +735,7 @@ namespace Squirrel
                     dir = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
                     break;
                 case ShortcutLocation.StartMenu:
-                    dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.StartMenu), "Programs", applicationName);
+                    dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.StartMenu), "Programs");
                     break;
                 case ShortcutLocation.Startup:
                     dir = Environment.GetFolderPath (Environment.SpecialFolder.Startup);


### PR DESCRIPTION
Creates the Start Menu shortcut directly in the Start Menu, removing the creation of an unnecessary subfolder by default. This is a cleaner and more modern practice, removing the need to expand a folder and making the menu appearance cleaner (W11 automatically hides it, so it is only a directory cleanup there).

I hope this is satisfactory.